### PR TITLE
Set the title for external video players

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/ActionBarHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/ActionBarHandler.java
@@ -201,11 +201,17 @@ public class ActionBarHandler {
         if(!videoTitle.isEmpty()) {
             if (PreferenceManager.getDefaultSharedPreferences(context)
                     .getBoolean(context.getString(R.string.useExternalPlayer), false)) {
+
+                // External Player
                 Intent intent = new Intent();
                 try {
                     intent.setAction(Intent.ACTION_VIEW);
+
                     intent.setDataAndType(Uri.parse(videoStreams[selectedStream].url),
                             VideoInfo.getMimeById(videoStreams[selectedStream].format));
+                    intent.putExtra(Intent.EXTRA_TITLE, videoTitle);
+                    intent.putExtra("title", videoTitle);
+
                     context.startActivity(intent);      // HERE !!!
                 } catch (Exception e) {
                     e.printStackTrace();
@@ -229,6 +235,7 @@ public class ActionBarHandler {
                     builder.create().show();
                 }
             } else {
+                // Internal Player
                 Intent intent = new Intent(context, PlayVideoActivity.class);
                 intent.putExtra(PlayVideoActivity.VIDEO_TITLE, videoTitle);
                 intent.putExtra(PlayVideoActivity.STREAM_URL, videoStreams[selectedStream].url);


### PR DESCRIPTION
This makes the external player experience nicer.

I had to set the title twice on the intent, since "Intent.EXTRA_TITLE" didn't work on MX Player. (MX Player's supported intent data is here: https://sites.google.com/site/mxvpen/api).

I think I did that correctly. Anyhow, it works. :)

