### PR TITLE
 fix bug with upload date + better way to parse it

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/VideoItemDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/VideoItemDetailFragment.java
@@ -35,7 +35,6 @@ import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Vector;

--- a/app/src/main/java/org/schabi/newpipe/VideoItemDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/VideoItemDetailFragment.java
@@ -32,6 +32,8 @@ import android.view.MenuItem;
 import java.net.URL;
 import java.text.DateFormat;
 import java.text.NumberFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -240,15 +242,14 @@ public class VideoItemDetailFragment extends Fragment {
                     thumbsUpView.setText(nf.format(info.like_count));
                     thumbsDownView.setText(nf.format(info.dislike_count));
 
-                    //this is horribly convoluted
-                    //TODO: find a better way to convert YYYY-MM-DD to a locale-specific date
-                    //suggestions are welcome
-                    int year  = Integer.parseInt(info.upload_date.substring(0, 4));
-                    int month = Integer.parseInt(info.upload_date.substring(5, 7));
-                    int date  = Integer.parseInt(info.upload_date.substring(8, 10));
-                    Calendar cal = Calendar.getInstance();
-                    cal.set(year, month, date);
-                    Date datum = cal.getTime();
+                    SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+                    Date datum = null;
+                    try {
+                        datum = formatter.parse(info.upload_date);
+                    } catch (ParseException e) {
+                        e.printStackTrace();
+                    }
+
                     DateFormat df = DateFormat.getDateInstance(DateFormat.MEDIUM, locale);
 
                     String localisedDate = df.format(datum);


### PR DESCRIPTION
The method to parse a date with spliting a string, that was used before, was actually buggy and showed one month ahead of actual upload date in the layout, e.g. Sep 18, 2015 instead of Aug 18, 2015
SimpleDateFormat was used instead.