### PR TITLE
Add contribution guidelines

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,27 @@
+#Contributing
+
+This document contains guidelines on making contributions to NewPipe.
+
+## Programming
+
+* Follow the [Google Style Guidelines](https://google.github.io/styleguide/javaguide.html)
+* Make a new feature on a seperate branch, not on the master branch
+* Make a pull request if you're done with your changes
+* When submitting changes, you agree that your code will be GPLv3 licensed
+
+## Commit messages
+
+* The subject line of your commit message shouldn't be longer than 72 characters
+* Try to keep each line of your commit message 72 characters to ensure proper
+ compatibility with all git tools
+* [This guide](http://chris.beams.io/posts/git-commit/) goes more in depth on what makes a good commit message
+
+## Translating
+
+* NewPipe can be translated on [weblate](https://hosted.weblate.org/projects/newpipe/strings/)
+
+## Communication
+
+* For the time being, [Slack](http://invite.chschtsch.ml/) is being used for project communication
+* Feel free to post suggestions, changes ideas etc.!
+* When making bug reports, be sure to tell which version you are using and the steps to reproduce the problem


### PR DESCRIPTION
Contribution guidelines are a helpful way to inform new potential
contributors about the way in which they can help with the project.

It's also a helpful way to enforce some consistent coding style and
quality among the contributions.