### PR TITLE
Fix view count parsing for large numbers

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/services/VideoExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/services/VideoExtractor.java
@@ -109,7 +109,7 @@ public abstract class VideoExtractor {
     protected abstract String getDescription();
     protected abstract String getUploader();
     protected abstract int getLength();
-    protected abstract int getViews();
+    protected abstract long getViews();
     protected abstract String getUploadDate();
     protected abstract String getThumbnailUrl();
     protected abstract String getUploaderThumbnailUrl();

--- a/app/src/main/java/org/schabi/newpipe/services/youtube/YoutubeVideoExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/services/youtube/YoutubeVideoExtractor.java
@@ -155,10 +155,10 @@ public class YoutubeVideoExtractor extends VideoExtractor {
     }
 
     @Override
-    public int getViews() {
+    public long getViews() {
         try {
             String viewCountString = doc.select("meta[itemprop=interactionCount]").attr("content");
-            return Integer.parseInt(viewCountString);
+            return Long.parseLong(viewCountString);
         } catch (Exception e) {//todo: find fallback method
             Log.e(TAG, "failed to number of views");
             e.printStackTrace();


### PR DESCRIPTION
Just noticed this today when testing the experimental audio player with Gangnam Style.
The patch plays well with view_count field of AbstractVideoInfo class as it is already of type long.