### PR TITLE
allow "panic button" apps to wipe activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,5 +84,18 @@
             android:name=".SettingsActivity"
             android:label="@string/title_activity_settings" >
         </activity>
+        <activity
+            android:name=".PanicResponderActivity"
+            android:launchMode="singleInstance"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="info.guardianproject.panic.action.TRIGGER" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".ExitActivity"
+            android:theme="@android:style/Theme.NoDisplay" />
     </application>
 </manifest>

--- a/app/src/main/java/org/schabi/newpipe/ExitActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/ExitActivity.java
@@ -1,0 +1,36 @@
+
+package org.schabi.newpipe;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+
+public class ExitActivity extends Activity {
+
+    @SuppressLint("NewApi")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            finishAndRemoveTask();
+        } else {
+            finish();
+        }
+
+        System.exit(0);
+    }
+
+    public static void exitAndRemoveFromRecentApps(Activity activity) {
+        Intent intent = new Intent(activity, ExitActivity.class);
+
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+                | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
+                | Intent.FLAG_ACTIVITY_CLEAR_TASK
+                | Intent.FLAG_ACTIVITY_NO_ANIMATION);
+
+        activity.startActivity(intent);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/PanicResponderActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/PanicResponderActivity.java
@@ -1,0 +1,32 @@
+
+package org.schabi.newpipe;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+
+public class PanicResponderActivity extends Activity {
+
+    public static final String PANIC_TRIGGER_ACTION = "info.guardianproject.panic.action.TRIGGER";
+
+    @SuppressLint("NewApi")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getIntent();
+        if (intent != null && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
+            // TODO explicitly clear the search results once they are restored when the app restarts
+            // or if the app reloads the current video after being killed, that should be cleared also
+            ExitActivity.exitAndRemoveFromRecentApps(this);
+        }
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            finishAndRemoveTask();
+        } else {
+            finish();
+        }
+    }
+}


### PR DESCRIPTION
This is a great app, I'm very excited to see a free software youtube player, and I like the nice, simple UI!

We (Guardian Project) have been developing "panic button" features in our apps for years, and now we are working to make a more flexible and open ecosystem of apps that can both trigger other apps, or respond to triggers. Since many people search for private topics on youtube, NewPipe is a natural panic responder app. This setup allows for easy configuration of a single trigger action which can then trigger multiple apps.

This single commit wipes NewPipe from the Recent Apps then exits when it is responding to a panic trigger.  Since NewPipe does not currently save the searches or current video, that has the effect of clearing the history.  Once NewPipe does save history, this will need to be updated to actually clear it.

The first panic button app that sends this kind of trigger is called Ripple, and it is available here:
https://github.com/guardianproject/ripple
https://play.google.com/store/apps/details?id=info.guardianproject.ripple

I'm adding support to this app right now:
https://panicbutton.io/
https://play.google.com/store/apps/details?id=org.iilab.pb

This is all code that I wrote, and you can have it under any license you want, including public domain. I waive all my copyright claims to it.  GPLv3 is a great license, we often use it in our apps.

You can see an example of this user experience in this video:
https://www.youtube.com/watch?v=mS1gstS6YS8

More info on the panic kit work here:
https://dev.guardianproject.info/projects/panic/wiki
