### PR TITLE
Tor support for all except streaming

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    
+
     lintOptions {
         checkReleaseBuilds false
         // Or, if you prefer, you can continue to check for errors in release builds,
@@ -35,4 +35,5 @@ dependencies {
     compile 'com.android.support:recyclerview-v7:23.1.1'
     compile 'org.jsoup:jsoup:1.8.3'
     compile 'org.mozilla:rhino:1.7.7'
+    compile 'info.guardianproject.netcipher:netcipher:1.2'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <application
+        android:name=".App"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:logo="@mipmap/ic_launcher"

--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -1,0 +1,32 @@
+package org.schabi.newpipe;
+
+import android.app.Application;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import info.guardianproject.netcipher.NetCipher;
+import info.guardianproject.netcipher.proxy.OrbotHelper;
+
+public class App extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        // if Orbot is installed, then default to using Tor, the user can still override
+        if (OrbotHelper.requestStartTor(this)) {
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+            configureTor(prefs.getBoolean(getString(R.string.useTor), true));
+        }
+    }
+
+    /**
+     * Set the proxy settings based on whether Tor should be enabled or not.
+     */
+    static void configureTor(boolean useTor) {
+        if (useTor) {
+            NetCipher.useTor();
+        } else {
+            NetCipher.setProxy(null);
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -39,4 +39,8 @@ public class App extends Application {
             OrbotHelper.requestStartTor(context);
         }
     }
+
+    static boolean isUsingTor() {
+        return useTor;
+    }
 }

--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe;
 
 import android.app.Application;
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
@@ -8,6 +9,8 @@ import info.guardianproject.netcipher.NetCipher;
 import info.guardianproject.netcipher.proxy.OrbotHelper;
 
 public class App extends Application {
+
+    private static boolean useTor;
 
     @Override
     public void onCreate() {
@@ -22,11 +25,18 @@ public class App extends Application {
     /**
      * Set the proxy settings based on whether Tor should be enabled or not.
      */
-    static void configureTor(boolean useTor) {
+    static void configureTor(boolean enabled) {
+        useTor = enabled;
         if (useTor) {
             NetCipher.useTor();
         } else {
             NetCipher.setProxy(null);
+        }
+    }
+
+    static void checkStartTor(Context context) {
+        if (useTor) {
+            OrbotHelper.requestStartTor(context);
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/DownloadDialog.java
@@ -61,17 +61,17 @@ public class DownloadDialog extends DialogFragment {
                         String suffix = "";
                         String title = arguments.getString(TITLE);
                         String url = "";
-                        String downloadFolder = "Download";
+                        String downloadFolder = Environment.DIRECTORY_DOWNLOADS;
                         switch(which) {
                             case 0:     // Video
                                 suffix = arguments.getString(FILE_SUFFIX_VIDEO);
                                 url = arguments.getString(VIDEO_URL);
-                                downloadFolder = "Movies";
+                                downloadFolder = Environment.DIRECTORY_MOVIES;
                                 break;
                             case 1:
                                 suffix = arguments.getString(FILE_SUFFIX_AUDIO);
                                 url = arguments.getString(AUDIO_URL);
-                                downloadFolder = "Music";
+                                downloadFolder = Environment.DIRECTORY_MUSIC;
                                 break;
                             default:
                                 Log.d(TAG, "lolz");

--- a/app/src/main/java/org/schabi/newpipe/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/DownloadDialog.java
@@ -90,7 +90,7 @@ public class DownloadDialog extends DialogFragment {
                         String saveFilePath = dir + "/" + title + suffix;
                         if (App.isUsingTor()) {
                             // if using Tor, do not use DownloadManager because the proxy cannot be set
-                            Downloader.downloadFile(url, saveFilePath);
+                            Downloader.downloadFile(getContext(), url, saveFilePath);
                         } else {
                             DownloadManager dm = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
                             DownloadManager.Request request = new DownloadManager.Request(

--- a/app/src/main/java/org/schabi/newpipe/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/DownloadDialog.java
@@ -87,15 +87,21 @@ public class DownloadDialog extends DialogFragment {
                                 //TODO notify user "download directory should be changed" ?
                             }
                         }
-                        DownloadManager dm = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
-                        DownloadManager.Request request = new DownloadManager.Request(
-                                Uri.parse(url));
-                        request.setDestinationUri(Uri.fromFile(new File(dir + "/" + title + suffix)));
-                        request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
-                        try {
-                            dm.enqueue(request);
-                        } catch (Exception e) {
-                            e.printStackTrace();
+                        String saveFilePath = dir + "/" + title + suffix;
+                        if (App.isUsingTor()) {
+                            // if using Tor, do not use DownloadManager because the proxy cannot be set
+                            Downloader.downloadFile(url, saveFilePath);
+                        } else {
+                            DownloadManager dm = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
+                            DownloadManager.Request request = new DownloadManager.Request(
+                                    Uri.parse(url));
+                            request.setDestinationUri(Uri.fromFile(new File(saveFilePath)));
+                            request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+                            try {
+                                dm.enqueue(request);
+                            } catch (Exception e) {
+                                e.printStackTrace();
+                            }
                         }
                     }
                 });

--- a/app/src/main/java/org/schabi/newpipe/Downloader.java
+++ b/app/src/main/java/org/schabi/newpipe/Downloader.java
@@ -7,6 +7,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.UnknownHostException;
 
+import javax.net.ssl.HttpsURLConnection;
+
 import info.guardianproject.netcipher.NetCipher;
 
 /**
@@ -43,7 +45,7 @@ public class Downloader {
         String ret = "";
         try {
             URL url = new URL(siteUrl);
-            HttpURLConnection con = (HttpURLConnection) NetCipher.getHttpURLConnection(url);
+            HttpsURLConnection con = NetCipher.getHttpsURLConnection(url);
             con.setRequestProperty("Accept-Language", language);
             ret = dl(con);
         }
@@ -88,7 +90,7 @@ public class Downloader {
 
         try {
             URL url = new URL(siteUrl);
-            HttpURLConnection con = (HttpURLConnection) NetCipher.getHttpURLConnection(url);
+            HttpsURLConnection con = NetCipher.getHttpsURLConnection(url);
             ret = dl(con);
         }
         catch(Exception e) {

--- a/app/src/main/java/org/schabi/newpipe/Downloader.java
+++ b/app/src/main/java/org/schabi/newpipe/Downloader.java
@@ -41,7 +41,6 @@ public class Downloader {
      * @param language the language (usually a 2-character code) to set as the preferred language
      * @return the contents of the specified text file*/
     public static String download(String siteUrl, String language) {
-        NetCipher.useTor();
         String ret = "";
         try {
             URL url = new URL(siteUrl);
@@ -86,7 +85,6 @@ public class Downloader {
  * @return the contents of the specified text file*/
     public static String download(String siteUrl) {
         String ret = "";
-        NetCipher.useTor();
 
         try {
             URL url = new URL(siteUrl);

--- a/app/src/main/java/org/schabi/newpipe/Downloader.java
+++ b/app/src/main/java/org/schabi/newpipe/Downloader.java
@@ -7,6 +7,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.UnknownHostException;
 
+import info.guardianproject.netcipher.NetCipher;
+
 /**
  * Created by Christian Schabesberger on 14.08.15.
  *
@@ -37,10 +39,11 @@ public class Downloader {
      * @param language the language (usually a 2-character code) to set as the preferred language
      * @return the contents of the specified text file*/
     public static String download(String siteUrl, String language) {
+        NetCipher.useTor();
         String ret = "";
         try {
             URL url = new URL(siteUrl);
-            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            HttpURLConnection con = (HttpURLConnection) NetCipher.getHttpURLConnection(url);
             con.setRequestProperty("Accept-Language", language);
             ret = dl(con);
         }
@@ -81,10 +84,11 @@ public class Downloader {
  * @return the contents of the specified text file*/
     public static String download(String siteUrl) {
         String ret = "";
+        NetCipher.useTor();
 
         try {
             URL url = new URL(siteUrl);
-            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            HttpURLConnection con = (HttpURLConnection) NetCipher.getHttpURLConnection(url);
             ret = dl(con);
         }
         catch(Exception e) {

--- a/app/src/main/java/org/schabi/newpipe/PlayVideoActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/PlayVideoActivity.java
@@ -188,6 +188,12 @@ public class PlayVideoActivity extends AppCompatActivity {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        App.checkStartTor(this);
+    }
+
+    @Override
     protected void onDestroy() {
         super.onDestroy();
         prefs = getPreferences(Context.MODE_PRIVATE);

--- a/app/src/main/java/org/schabi/newpipe/PlayVideoActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/PlayVideoActivity.java
@@ -27,6 +27,7 @@ import android.widget.MediaController;
 import android.widget.ProgressBar;
 import android.widget.VideoView;
 import info.guardianproject.netcipher.NetCipher;
+import info.guardianproject.netcipher.proxy.OrbotHelper;
 
 /**
  * Copyright (C) Christian Schabesberger 2015 <chris.schabesberger@mailbox.org>
@@ -362,7 +363,8 @@ public class PlayVideoActivity extends AppCompatActivity implements OnSharedPref
     }
 
     private void setTorPreference(SharedPreferences prefs) {
-        if(prefs.getBoolean(getString(R.string.useTor), false)) {
+        // if Orbot is installed, then default to using Tor, the user can still override
+        if(prefs.getBoolean(getString(R.string.useTor), OrbotHelper.isOrbotInstalled(this))) {
             NetCipher.useTor();
         } else {
             NetCipher.setProxy(null);

--- a/app/src/main/java/org/schabi/newpipe/PlayVideoActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/PlayVideoActivity.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.media.MediaPlayer;
@@ -25,6 +26,7 @@ import android.widget.Button;
 import android.widget.MediaController;
 import android.widget.ProgressBar;
 import android.widget.VideoView;
+import info.guardianproject.netcipher.NetCipher;
 
 /**
  * Copyright (C) Christian Schabesberger 2015 <chris.schabesberger@mailbox.org>
@@ -44,7 +46,7 @@ import android.widget.VideoView;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class PlayVideoActivity extends AppCompatActivity {
+public class PlayVideoActivity extends AppCompatActivity implements OnSharedPreferenceChangeListener {
 
     //// TODO: 11.09.15 add "choose stream" menu 
     
@@ -170,6 +172,9 @@ public class PlayVideoActivity extends AppCompatActivity {
         if(prefs.getBoolean(PREF_IS_LANDSCAPE, false) && !isLandscape) {
             toggleOrientation();
         }
+
+        setTorPreference(prefs);
+        prefs.registerOnSharedPreferenceChangeListener(this);
     }
 
     @Override
@@ -185,6 +190,13 @@ public class PlayVideoActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         videoView.pause();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        prefs = getPreferences(Context.MODE_PRIVATE);
+        prefs.unregisterOnSharedPreferenceChangeListener(this);
     }
 
     @Override
@@ -348,4 +360,20 @@ public class PlayVideoActivity extends AppCompatActivity {
         editor.putBoolean(PREF_IS_LANDSCAPE, isLandscape);
         editor.apply();
     }
+
+    private void setTorPreference(SharedPreferences prefs) {
+        if(prefs.getBoolean(getString(R.string.useTor), false)) {
+            NetCipher.useTor();
+        } else {
+            NetCipher.setProxy(null);
+        }
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences prefs, String key) {
+        if(key.equals(getString(R.string.useTor))) {
+            setTorPreference(prefs);
+        }
+    }
+
 }

--- a/app/src/main/java/org/schabi/newpipe/PlayVideoActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/PlayVideoActivity.java
@@ -3,7 +3,6 @@ package org.schabi.newpipe;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.media.MediaPlayer;
@@ -26,8 +25,6 @@ import android.widget.Button;
 import android.widget.MediaController;
 import android.widget.ProgressBar;
 import android.widget.VideoView;
-import info.guardianproject.netcipher.NetCipher;
-import info.guardianproject.netcipher.proxy.OrbotHelper;
 
 /**
  * Copyright (C) Christian Schabesberger 2015 <chris.schabesberger@mailbox.org>
@@ -47,7 +44,7 @@ import info.guardianproject.netcipher.proxy.OrbotHelper;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class PlayVideoActivity extends AppCompatActivity implements OnSharedPreferenceChangeListener {
+public class PlayVideoActivity extends AppCompatActivity {
 
     //// TODO: 11.09.15 add "choose stream" menu 
     
@@ -173,9 +170,6 @@ public class PlayVideoActivity extends AppCompatActivity implements OnSharedPref
         if(prefs.getBoolean(PREF_IS_LANDSCAPE, false) && !isLandscape) {
             toggleOrientation();
         }
-
-        setTorPreference(prefs);
-        prefs.registerOnSharedPreferenceChangeListener(this);
     }
 
     @Override
@@ -197,7 +191,6 @@ public class PlayVideoActivity extends AppCompatActivity implements OnSharedPref
     protected void onDestroy() {
         super.onDestroy();
         prefs = getPreferences(Context.MODE_PRIVATE);
-        prefs.unregisterOnSharedPreferenceChangeListener(this);
     }
 
     @Override
@@ -361,21 +354,4 @@ public class PlayVideoActivity extends AppCompatActivity implements OnSharedPref
         editor.putBoolean(PREF_IS_LANDSCAPE, isLandscape);
         editor.apply();
     }
-
-    private void setTorPreference(SharedPreferences prefs) {
-        // if Orbot is installed, then default to using Tor, the user can still override
-        if(prefs.getBoolean(getString(R.string.useTor), OrbotHelper.isOrbotInstalled(this))) {
-            NetCipher.useTor();
-        } else {
-            NetCipher.setProxy(null);
-        }
-    }
-
-    @Override
-    public void onSharedPreferenceChanged(SharedPreferences prefs, String key) {
-        if(key.equals(getString(R.string.useTor))) {
-            setTorPreference(prefs);
-        }
-    }
-
 }

--- a/app/src/main/java/org/schabi/newpipe/SettingsActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/SettingsActivity.java
@@ -1,5 +1,8 @@
 package org.schabi.newpipe;
 
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
@@ -39,6 +42,7 @@ import info.guardianproject.netcipher.proxy.OrbotHelper;
 
 public class SettingsActivity extends PreferenceActivity {
 
+    private static final int REQUEST_INSTALL_ORBOT = 0x1234;
     private AppCompatDelegate mDelegate = null;
 
     @Override
@@ -65,17 +69,37 @@ public class SettingsActivity extends PreferenceActivity {
 
             // if Orbot is installed, then default to using Tor, the user can still override
             useTorCheckBox = (CheckBoxPreference) findPreference(getString(R.string.useTor));
-            boolean useTor = OrbotHelper.isOrbotInstalled(getActivity());
+            final Activity activity = getActivity();
+            final boolean useTor = OrbotHelper.isOrbotInstalled(activity);
             useTorCheckBox.setDefaultValue(useTor);
             useTorCheckBox.setChecked(useTor);
             useTorCheckBox.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
-                public boolean onPreferenceChange(Preference preference, Object useTor) {
-                    App.configureTor((Boolean) useTor);
+                public boolean onPreferenceChange(Preference preference, Object o) {
+                    boolean useTor = (Boolean) o;
+                    if (useTor) {
+                        if (OrbotHelper.isOrbotInstalled(activity)) {
+                            App.configureTor(true);
+                        } else {
+                            Intent intent = OrbotHelper.getOrbotInstallIntent(activity);
+                            activity.startActivityForResult(intent, REQUEST_INSTALL_ORBOT);
+                        }
+                    } else {
+                        App.configureTor(false);
+                    }
                     return true;
                 }
             });
         }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        // try to start tor regardless of resultCode since clicking back after
+        // installing the app does not necessarily return RESULT_OK
+        App.configureTor(requestCode == REQUEST_INSTALL_ORBOT
+                && OrbotHelper.requestStartTor(this));
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/SettingsActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/SettingsActivity.java
@@ -2,6 +2,8 @@ package org.schabi.newpipe;
 
 import android.content.res.Configuration;
 import android.os.Bundle;
+import android.preference.CheckBoxPreference;
+import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceFragment;
 import android.support.annotation.LayoutRes;
@@ -12,6 +14,8 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+
+import info.guardianproject.netcipher.proxy.OrbotHelper;
 
 /**
  * Created by Christian Schabesberger on 31.08.15.
@@ -52,10 +56,25 @@ public class SettingsActivity extends PreferenceActivity {
     }
 
     public static class SettingsFragment extends PreferenceFragment {
+        private CheckBoxPreference useTorCheckBox;
+
         @Override
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
             addPreferencesFromResource(R.xml.settings_screen);
+
+            // if Orbot is installed, then default to using Tor, the user can still override
+            useTorCheckBox = (CheckBoxPreference) findPreference(getString(R.string.useTor));
+            boolean useTor = OrbotHelper.isOrbotInstalled(getActivity());
+            useTorCheckBox.setDefaultValue(useTor);
+            useTorCheckBox.setChecked(useTor);
+            useTorCheckBox.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object useTor) {
+                    App.configureTor((Boolean) useTor);
+                    return true;
+                }
+            });
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/VideoItemDetailActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/VideoItemDetailActivity.java
@@ -114,6 +114,12 @@ public class VideoItemDetailActivity extends AppCompatActivity {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        App.checkStartTor(this);
+    }
+
+    @Override
     public void onSaveInstanceState(Bundle outState) {
         outState.putString(VideoItemDetailFragment.VIDEO_URL, videoUrl);
         outState.putInt(VideoItemDetailFragment.STREAMING_SERVICE, currentStreamingService);

--- a/app/src/main/java/org/schabi/newpipe/VideoItemListActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/VideoItemListActivity.java
@@ -175,6 +175,12 @@ public class VideoItemListActivity extends AppCompatActivity
         PreferenceManager.setDefaultValues(this, R.xml.settings_screen, false);
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        App.checkStartTor(this);
+    }
+
     /**
      * Callback method from {@link VideoItemListFragment.Callbacks}
      * indicating that the item with the given ID was selected.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,5 +64,5 @@
     <string name="detailThumbsDownImgViewDescription">Dislikes</string>
     <string name="detailThumbsUpImgViewDescription">Likes</string>
     <string name="useTor">Use Tor</string>
-    <string name="useTorTitle">Proxy connections via The Onion Router</string>
+    <string name="useTorSummary">Force download traffic through Tor for increased privacy (streaming videos not yet supported)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,4 +63,6 @@
     <string name="detailUploaderThumbnailViewDescription">Uploader thumbnail</string>
     <string name="detailThumbsDownImgViewDescription">Dislikes</string>
     <string name="detailThumbsUpImgViewDescription">Likes</string>
+    <string name="useTor">Use Tor</string>
+    <string name="useTorTitle">Proxy connections via The Onion Router</string>
 </resources>

--- a/app/src/main/res/xml/settings_screen.xml
+++ b/app/src/main/res/xml/settings_screen.xml
@@ -75,8 +75,7 @@
         <CheckBoxPreference
             android:key="@string/useTor"
             android:title="@string/useTor"
-            android:summary="@string/useTorSummary"
-            android:defaultValue="false"/>
+            android:summary="@string/useTorSummary" />
 
     </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/xml/settings_screen.xml
+++ b/app/src/main/res/xml/settings_screen.xml
@@ -72,5 +72,10 @@
             android:summary="@string/autoPlayThroughIntentSummary"
             android:defaultValue="false" />
 
+        <CheckBoxPreference
+            android:key="@string/useTor"
+            android:title="@string/useTorTitle"
+            android:defaultValue="false"/>
+
     </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/xml/settings_screen.xml
+++ b/app/src/main/res/xml/settings_screen.xml
@@ -74,7 +74,8 @@
 
         <CheckBoxPreference
             android:key="@string/useTor"
-            android:title="@string/useTorTitle"
+            android:title="@string/useTor"
+            android:summary="@string/useTorSummary"
             android:defaultValue="false"/>
 
     </PreferenceCategory>


### PR DESCRIPTION
I started with @gjedeer 's work and then worked on making Tor support more tightly integrated.  Since `DownloadManager` does not let you set the proxy settings, I wrote a basic, custom download manager for downloading over Tor.  This does not touch the video streaming at all, so with "Use Tor" enabled, video streaming will not go over Tor.  That'll require ExoPlayer, I think.

Ideally, NewPipe would represent the state of Tor in the UI somehow.  Orbot will broadcast out the status, and its easy to receive that with a `BroadcastReceiver`.  The open question is how to represent the state of Tor in the UX.  The states are `OFF, STARTING, ON, STOPPING`.