### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
@@ -564,9 +564,9 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                     }
                 }
 
-                int seconds = (secondsString.isEmpty() ? 0 : Integer.parseInt(secondsString));
-                int minutes = (minutesString.isEmpty() ? 0 : Integer.parseInt(minutesString));
-                int hours = (hoursString.isEmpty() ? 0 : Integer.parseInt(hoursString));
+                int seconds = secondsString.isEmpty() ? 0 : Integer.parseInt(secondsString);
+                int minutes = minutesString.isEmpty() ? 0 : Integer.parseInt(minutesString);
+                int hours = hoursString.isEmpty() ? 0 : Integer.parseInt(hoursString);
 
                 //don't trust BODMAS!
                 int ret = seconds + (60 * minutes) + (3600 * hours);
@@ -794,7 +794,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         } finally {
             Context.exit();
         }
-        return (result == null ? "" : result.toString());
+        return result == null ? "" : result.toString();
     }
 
     private String findErrorReason(Document doc) {

--- a/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
@@ -157,7 +157,7 @@ public class BackgroundPlayer extends Service /*implements MediaPlayer.OnPrepare
                 e.printStackTrace();
             }
 
-            WifiManager wifiMgr = ((WifiManager)getSystemService(Context.WIFI_SERVICE));
+            WifiManager wifiMgr = (WifiManager)getSystemService(Context.WIFI_SERVICE);
             wifiLock = wifiMgr.createWifiLock(WifiManager.WIFI_MODE_FULL, TAG);
 
             //listen for end of video

--- a/app/src/main/java/org/schabi/newpipe/player/PlayVideoActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayVideoActivity.java
@@ -327,7 +327,7 @@ public class PlayVideoActivity extends AppCompatActivity {
 
             int realHeight = realDisplayMetrics.heightPixels;
             int displayHeight = displayMetrics.heightPixels;
-            return (realHeight - displayHeight);
+            return realHeight - displayHeight;
         } else {
             return 50;
         }
@@ -344,7 +344,7 @@ public class PlayVideoActivity extends AppCompatActivity {
 
             int realWidth = realDisplayMetrics.widthPixels;
             int displayWidth = displayMetrics.widthPixels;
-            return (realWidth - displayWidth);
+            return realWidth - displayWidth;
         } else {
             return 50;
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed