### PR TITLE
Code quality fix - Local variable and method parameter names should comply with a naming convention.

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/VideoInfoItemViewCreator.java
+++ b/app/src/main/java/org/schabi/newpipe/VideoInfoItemViewCreator.java
@@ -102,15 +102,15 @@ class VideoInfoItemViewCreator {
         public TextView itemVideoTitleView, itemUploaderView, itemDurationView, itemUploadDateView, itemViewCountView;
     }
 
-    private String shortViewCount(Long view_count){
-        if(view_count >= 1000000000){
-            return Long.toString(view_count/1000000000)+"B views";
-        }else if(view_count>=1000000){
-            return Long.toString(view_count/1000000)+"M views";
-        }else if(view_count>=1000){
-            return Long.toString(view_count/1000)+"K views";
+    private String shortViewCount(Long viewCount){
+        if(viewCount >= 1000000000){
+            return Long.toString(viewCount/1000000000)+"B views";
+        }else if(viewCount>=1000000){
+            return Long.toString(viewCount/1000000)+"M views";
+        }else if(viewCount>=1000){
+            return Long.toString(viewCount/1000)+"K views";
         }else {
-            return Long.toString(view_count)+" views";
+            return Long.toString(viewCount)+" views";
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/VideoItemDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/VideoItemDetailFragment.java
@@ -247,9 +247,9 @@ public class VideoItemDetailFragment extends Fragment {
         public void run() {
             Activity a = getActivity();
             if(a != null) {
-                boolean show_age_restricted_content = PreferenceManager.getDefaultSharedPreferences(a)
+                boolean showAgeRestrictedContent = PreferenceManager.getDefaultSharedPreferences(a)
                         .getBoolean(activity.getString(R.string.show_age_restricted_content), false);
-                if (streamInfo.age_limit == 0 || show_age_restricted_content) {
+                if (streamInfo.age_limit == 0 || showAgeRestrictedContent) {
                     updateInfo(streamInfo);
                 } else {
                     onNotSpecifiedContentErrorWithMessage(R.string.video_is_age_restricted);

--- a/app/src/main/java/org/schabi/newpipe/VideoItemListActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/VideoItemListActivity.java
@@ -272,14 +272,14 @@ public class VideoItemListActivity extends AppCompatActivity
                 getSupportFragmentManager()
                         .findFragmentById(R.id.videoitem_list))
                 .getListAdapter();
-        String webpage_url = listAdapter.getVideoList().get((int) Long.parseLong(id)).webpage_url;
+        String webpageUrl = listAdapter.getVideoList().get((int) Long.parseLong(id)).webpage_url;
         if (mTwoPane) {
             // In two-pane mode, show the detail view in this activity by
             // adding or replacing the detail fragment using a
             // fragment transaction.
             Bundle arguments = new Bundle();
             //arguments.putString(VideoItemDetailFragment.ARG_ITEM_ID, id);
-            arguments.putString(VideoItemDetailFragment.VIDEO_URL, webpage_url);
+            arguments.putString(VideoItemDetailFragment.VIDEO_URL, webpageUrl);
             arguments.putInt(VideoItemDetailFragment.STREAMING_SERVICE, currentStreamingServiceId);
             videoFragment = new VideoItemDetailFragment();
             videoFragment.setArguments(arguments);
@@ -298,7 +298,7 @@ public class VideoItemListActivity extends AppCompatActivity
             // for the selected item ID.
             Intent detailIntent = new Intent(this, VideoItemDetailActivity.class);
             //detailIntent.putExtra(VideoItemDetailFragment.ARG_ITEM_ID, id);
-            detailIntent.putExtra(VideoItemDetailFragment.VIDEO_URL, webpage_url);
+            detailIntent.putExtra(VideoItemDetailFragment.VIDEO_URL, webpageUrl);
             detailIntent.putExtra(VideoItemDetailFragment.STREAMING_SERVICE, currentStreamingServiceId);
             startActivity(detailIntent);
         }

--- a/app/src/main/java/org/schabi/newpipe/extractor/Parser.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/Parser.java
@@ -54,11 +54,11 @@ public class Parser {
     public static Map<String, String> compatParseMap(final String input) throws UnsupportedEncodingException {
         Map<String, String> map = new HashMap<>();
         for(String arg : input.split("&")) {
-            String[] split_arg = arg.split("=");
-            if(split_arg.length > 1) {
-                map.put(split_arg[0], URLDecoder.decode(split_arg[1], "UTF-8"));
+            String[] splitArg = arg.split("=");
+            if(splitArg.length > 1) {
+                map.put(splitArg[0], URLDecoder.decode(splitArg[1], "UTF-8"));
             } else {
-                map.put(split_arg[0], "");
+                map.put(splitArg[0], "");
             }
         }
         return map;

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
@@ -435,14 +435,14 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     public List<AudioStream> getAudioStreams() throws ParsingException {
         Vector<AudioStream> audioStreams = new Vector<>();
         try{
-            String encoded_url_map;
+            String encodedUrlMap;
             // playerArgs could be null if the video is age restricted
             if (playerArgs == null) {
-                encoded_url_map = videoInfoPage.get("adaptive_fmts");
+                encodedUrlMap = videoInfoPage.get("adaptive_fmts");
             } else {
-                encoded_url_map = playerArgs.getString("adaptive_fmts");
+                encodedUrlMap = playerArgs.getString("adaptive_fmts");
             }
-            for(String url_data_str : encoded_url_map.split(",")) {
+            for(String url_data_str : encodedUrlMap.split(",")) {
                 // This loop iterates through multiple streams, therefor tags
                 // is related to one and the same stream at a time.
                 Map<String, String> tags = Parser.compatParseMap(
@@ -478,14 +478,14 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         Vector<VideoStream> videoStreams = new Vector<>();
 
         try{
-            String encoded_url_map;
+            String encodedUrlMap;
             // playerArgs could be null if the video is age restricted
             if (playerArgs == null) {
-                encoded_url_map = videoInfoPage.get("url_encoded_fmt_stream_map");
+                encodedUrlMap = videoInfoPage.get("url_encoded_fmt_stream_map");
             } else {
-                encoded_url_map = playerArgs.getString("url_encoded_fmt_stream_map");
+                encodedUrlMap = playerArgs.getString("url_encoded_fmt_stream_map");
             }
-            for(String url_data_str : encoded_url_map.split(",")) {
+            for(String url_data_str : encodedUrlMap.split(",")) {
                 try {
                     // This loop iterates through multiple streams, therefor tags
                     // is related to one and the same stream at a time.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S00117- Local variable and method parameter names should comply with a naming convention.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S00117

Please let me know if you have any questions.

Faisal Hameed