### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/Localization.java
+++ b/app/src/main/java/org/schabi/newpipe/Localization.java
@@ -34,6 +34,9 @@ import java.util.Locale;
 
 public class Localization {
 
+    private Localization() {
+    }
+
     public static Locale getPreferredLocale(Context context) {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
 

--- a/app/src/main/java/org/schabi/newpipe/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/NewPipeSettings.java
@@ -33,6 +33,10 @@ import java.io.File;
  * Helper for global settings
  */
 public class NewPipeSettings {
+
+    private NewPipeSettings() {
+    }
+
     public static void initSettings(Context context) {
         PreferenceManager.setDefaultValues(context, R.xml.settings, false);
         getVideoDownloadFolder(context);

--- a/app/src/main/java/org/schabi/newpipe/extractor/DashMpdParser.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/DashMpdParser.java
@@ -31,6 +31,9 @@ import java.util.Vector;
 
 public class DashMpdParser {
 
+    private DashMpdParser() {
+    }
+
     static class DashMpdParsingException extends ParsingException {
         DashMpdParsingException(String message, Exception e) {
             super(message, e);

--- a/app/src/main/java/org/schabi/newpipe/extractor/Parser.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/Parser.java
@@ -32,6 +32,9 @@ import java.util.regex.Pattern;
 /** avoid using regex !!! */
 public class Parser {
 
+    private Parser() {
+    }
+
     public static class RegexException extends ParsingException {
         public RegexException(String message) {
             super(message);

--- a/app/src/main/java/org/schabi/newpipe/extractor/ServiceList.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/ServiceList.java
@@ -29,6 +29,10 @@ import org.schabi.newpipe.extractor.services.youtube.YoutubeService;
 
 @SuppressWarnings("ALL")
 public class ServiceList {
+
+    private ServiceList() {
+    }
+
     private static final String TAG = ServiceList.class.toString();
     private static final StreamingService[] services = {
         new YoutubeService(0)

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -23,6 +23,10 @@ import org.schabi.newpipe.extractor.ParsingException;
  */
 
 public class YoutubeParsingHelper {
+
+    private YoutubeParsingHelper() {
+    }
+
     public static int parseDurationString(String input)
             throws ParsingException, NumberFormatException {
         String[] splitInput = input.split(":");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed