### PR TITLE
General code quality fix-1

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/Downloader.java
+++ b/app/src/main/java/org/schabi/newpipe/Downloader.java
@@ -50,14 +50,12 @@ public class Downloader implements org.schabi.newpipe.extractor.Downloader {
     /**Common functionality between download(String url) and download(String url, String language)*/
     private static String dl(HttpsURLConnection con) throws IOException {
         StringBuilder response = new StringBuilder();
-        BufferedReader in = null;
 
-        try {
+        try (BufferedReader in = new BufferedReader(
+                new InputStreamReader(con.getInputStream()))){
             con.setRequestMethod("GET");
             con.setRequestProperty("User-Agent", USER_AGENT);
 
-            in = new BufferedReader(
-                    new InputStreamReader(con.getInputStream()));
             String inputLine;
 
             while((inputLine = in.readLine()) != null) {
@@ -68,10 +66,6 @@ public class Downloader implements org.schabi.newpipe.extractor.Downloader {
             //Toast.makeText(getActivity(), uhe.getMessage(), Toast.LENGTH_LONG).show();
         } catch(Exception e) {
             throw new IOException(e);
-        } finally {
-            if(in != null) {
-                in.close();
-            }
         }
 
         return response.toString();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness. 
squid:S2293 - The diamond operator ("<>") should be used. 
squid:S2093 -  Try-with-resources should be used.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S2293
https://dev.eclipse.org/sonar/rules/show/squid:S2093
https://dev.eclipse.org/sonar/rules/show/squid:S1488

Please let me know if you have any questions.

Faisal Hameed