### PR TITLE
General code quality fix-2

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/extractor/youtube/YoutubeSearchEngineTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/extractor/youtube/YoutubeSearchEngineTest.java
@@ -101,7 +101,7 @@ public class YoutubeSearchEngineTest extends AndroidTestCase {
     }
 
     public void testIfSuggestionsAreReplied() {
-        assertEquals(suggestionReply.size() > 0, true);
+        assertEquals(!suggestionReply.isEmpty(), true);
     }
 
     public void testIfSuggestionsAreValid() {

--- a/app/src/main/java/org/schabi/newpipe/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/DownloadDialog.java
@@ -130,7 +130,7 @@ public class DownloadDialog extends DialogFragment {
     private String createFileName(String fName) {
         // from http://eng-przemelek.blogspot.de/2009/07/how-to-create-valid-file-name.html
 
-        List<String> forbiddenCharsPatterns = new ArrayList<String> ();
+        List<String> forbiddenCharsPatterns = new ArrayList<> ();
         forbiddenCharsPatterns.add("[:]+"); // Mac OS, but it looks that also Windows XP
         forbiddenCharsPatterns.add("[\\*\"/\\\\\\[\\]\\:\\;\\|\\=\\,]+");  // Windows
         forbiddenCharsPatterns.add("[^\\w\\d\\.]+");  // last chance... only latin letters and digits

--- a/app/src/main/java/org/schabi/newpipe/extractor/StreamInfo.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/StreamInfo.java
@@ -127,7 +127,7 @@ public class StreamInfo extends AbstractVideoInfo {
         // also try to get streams from the dashMpd
         if(streamInfo.dashMpdUrl != null && !streamInfo.dashMpdUrl.isEmpty()) {
             if(streamInfo.audio_streams == null) {
-                streamInfo.audio_streams = new Vector<AudioStream>();
+                streamInfo.audio_streams = new Vector<>();
             }
             //todo: make this quick and dirty solution a real fallback
             // same as the quick and dirty aboth

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
@@ -569,9 +569,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                 int hours = (hoursString.isEmpty() ? 0 : Integer.parseInt(hoursString));
 
                 //don't trust BODMAS!
-                int ret = seconds + (60 * minutes) + (3600 * hours);
+                return seconds + (60 * minutes) + (3600 * hours);
                 //Log.d(TAG, "derived timestamp value:"+ret);
-                return ret;
                 //the ordering varies internationally
             } catch (ParsingException e) {
                 throw new ParsingException("Could not get timestamp.", e);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness. 
squid:S2293 - The diamond operator ("<>") should be used. 
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S2293
https://dev.eclipse.org/sonar/rules/show/squid:S1488

Please let me know if you have any questions.

Faisal Hameed