### PR TITLE
Let's tweak the UI strings a bit

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -25,7 +25,7 @@
     <string name="background_player_name">مشغل NewPipe في الخلفية</string>
     <string name="background_player_playing_toast">جاري التشغيل في الخلفية</string>
     <string name="cancel">إلغاء</string>
-    <string name="choose_browser">إختر متصفح:</string>
+    <string name="choose_browser">إختر متصفح</string>
     <string name="dark_theme_title">مظلم</string>
     <string name="default_audio_format_title">صيغة الصوت الإفتراضية</string>
     <string name="default_resolution_title">الدقة الإفتراضية</string>
@@ -67,7 +67,7 @@
     <string name="settings_category_other_title">تعريب JetSub مدونة درويديات</string>
     <string name="settings_category_video_audio_title">الفيديو والصوتيات</string>
     <string name="share">مشاركة</string>
-    <string name="share_dialog_title">مشاركة بواسطة:</string>
+    <string name="share_dialog_title">مشاركة بواسطة</string>
     <string name="show_next_and_similar_title">عرض التالي والفيديوهات المشابهة</string>
     <string name="show_play_with_kodi_summary">عرض خيار لتشغيل الفيديو بواسطة Kodi Media Center.</string>
     <string name="show_play_with_kodi_title">عرض خيار التشغيل بواسطة Kodi.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -11,8 +11,8 @@
     <string name="settings">Nastavení</string>
     <string name="did_you_mean">Měli jste na mysli: %1$s?</string>
     <string name="search_page">"Vyhledat stránku: "</string>
-    <string name="share_dialog_title">Sdílet s:</string>
-    <string name="choose_browser">Vybrat prohlížeč:</string>
+    <string name="share_dialog_title">Sdílet s</string>
+    <string name="choose_browser">Vybrat prohlížeč</string>
     <string name="screen_rotation">otočení</string>
     <string name="settings_activity_title">Nastavení</string>
     <string name="use_external_video_player_title">Použít externí video přehrávač</string>
@@ -72,7 +72,7 @@
 
     <string name="err_dir_create">Nebylo možné vytvořit složku pro stažené soubory \'%1$s\'</string>
     <string name="info_dir_created">Vytvořena složka pro stažené soubory \'%1$s\'</string>
-<string name="autoplay_by_calling_app_title">Automaticky přehrávat při otevření z jiné aplikace.</string>
+<string name="autoplay_by_calling_app_title">Automaticky přehrávat při otevření z jiné aplikace</string>
     <string name="autoplay_by_calling_app_summary">Automaticky přehrát video, když je NewPipe otevřen z jiné aplikace.</string>
     <string name="content">Obsah</string>
     <string name="show_age_restricted_content_title">Zobrazovat věkově omezený obsah</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -12,8 +12,8 @@
     <string name="settings">Einstellungen</string>
     <string name="did_you_mean">Meintest du: %1$s ?</string>
     <string name="search_page">Suchseite: </string>
-    <string name="share_dialog_title">Teilen mit:</string>
-    <string name="choose_browser">Browser:</string>
+    <string name="share_dialog_title">Teilen mit</string>
+    <string name="choose_browser">Browser</string>
     <string name="screen_rotation">Rotation</string>
     <string name="settings_activity_title">Einstellungen</string>
     <string name="useExternalPlayerTitle">Externen Player benutzen</string>
@@ -120,7 +120,7 @@
     <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">Dieses Gerät stellt keinen abgesicherten Dekodierer für <xliff:g id="mime_type">%1$s</xliff:g> bereit</string>
     <string name="could_not_get_stream">Konnte keinen Stream holen.</string>
     <string name="error_drm_not_supported">Geschützte Inhalte werden von API-Ebenen unterhalb von 18 nicht unterstützt</string>
-    <string name="autoplay_by_calling_app_title">Bei Aufruf aus einer anderen App automatisch abspielen.</string>
+    <string name="autoplay_by_calling_app_title">Bei Aufruf aus einer anderen App automatisch abspielen</string>
     <string name="autoplay_by_calling_app_summary">Spielt ein Video automatisch ab, wenn NewPipe von einer anderen App aufgerufen wurde.</string>
     <string name="report_error">Einen Fehler melden</string>
     <string name="user_report">Anwenderbericht</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -13,8 +13,8 @@
     <string name="settings">Ρυθμίσεις</string>
     <string name="did_you_mean">"Μήπως εννοείτε: "</string>
     <string name="search_page">"Αναζήτηση σελίδας: "</string>
-    <string name="share_dialog_title">Κοινοποίηση με:</string>
-    <string name="choose_browser">Επιλέξτε browser:</string>
+    <string name="share_dialog_title">Κοινοποίηση με</string>
+    <string name="choose_browser">Επιλέξτε browser</string>
     <string name="screen_rotation">περιστροφή</string>
     <string name="settings_activity_title">Ρυθμίσεις</string>
     <string name="use_external_video_player_title">Χρήση εξωτερικού video player</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -12,8 +12,8 @@
     <string name="settings">Agordoj</string>
     <string name="did_you_mean">"Ĉu vi intencis: "</string>
     <string name="search_page">"Serĉpaĝo: "</string>
-    <string name="share_dialog_title">Konigi kun:</string>
-    <string name="choose_browser">Elekti retumilon:</string>
+    <string name="share_dialog_title">Konigi kun</string>
+    <string name="choose_browser">Elekti retumilon</string>
     <string name="screen_rotation">turno</string>
     <string name="settings_activity_title">Agordoj</string>
     <string name="use_external_video_player_title">Uzi eksteran videoludilon</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -12,8 +12,8 @@
     <string name="settings">Ajustes</string>
     <string name="did_you_mean">"¿Querías decir?: "</string>
     <string name="search_page">Buscar página: </string>
-    <string name="share_dialog_title">Compartir con:</string>
-    <string name="choose_browser">Selecciona navegador:</string>
+    <string name="share_dialog_title">Compartir con</string>
+    <string name="choose_browser">Selecciona navegador</string>
     <string name="screen_rotation">rotación</string>
     <string name="settings_activity_title">Ajustes</string>
     <string name="useExternalPlayerTitle">Usar reproductor externo</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -9,8 +9,8 @@
     <string name="download">Deskargatu</string>
     <string name="search">Bilatu</string>
     <string name="settings">Ezarpenak</string>
-    <string name="share_dialog_title">Partekatu honekin:</string>
-    <string name="choose_browser">Nabigatzailea aukeratu:</string>
+    <string name="share_dialog_title">Partekatu honekin</string>
+    <string name="choose_browser">Nabigatzailea aukeratu</string>
     <string name="screen_rotation">biratzea</string>
     <string name="settings_activity_title">Ezarpenak</string>
     <string name="download_path_title">Deskargatzeko kokapena</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="autoplay_through_intent_summary">Lire automatiquement une vidéo lorsqu’elle a été appelée depuis une autre application.</string>
     <string name="cancel">Annuler</string>
-    <string name="choose_browser">Choisir un navigateur :</string>
+    <string name="choose_browser">Choisir un navigateur </string>
     <string name="default_resolution_title">Définition par défaut</string>
     <string name="did_you_mean">"S’agirait-il de : "</string>
     <string name="download">Télécharger</string>
@@ -21,7 +21,7 @@
     <string name="search_page">"Rechercher dans la page : "</string>
     <string name="settings">Paramètres</string>
     <string name="share">Partager</string>
-    <string name="share_dialog_title">Partager avec :</string>
+    <string name="share_dialog_title">Partager avec </string>
     <string name="show_play_with_kodi_summary">Afficher une option pour lire la vidéo via la médiathèque Kodi.</string>
     <string name="show_play_with_kodi_title">Afficher l’option « Lire avec Kodi »</string>
     <string name="settings_activity_title">Paramètres</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -12,8 +12,8 @@
     <string name="settings">Beállítások</string>
     <string name="did_you_mean">Erre gondolt: </string>
     <string name="search_page">"Keresőlap: "</string>
-    <string name="share_dialog_title">Megosztás ezzel:</string>
-    <string name="choose_browser">Válasszon böngészőt:</string>
+    <string name="share_dialog_title">Megosztás ezzel</string>
+    <string name="choose_browser">Válasszon böngészőt</string>
     <string name="screen_rotation">forgatás</string>
     <string name="settings_activity_title">Beállítások</string>
     <string name="useExternalPlayerTitle">Külső lejátszó használata</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -11,8 +11,8 @@
     <string name="settings">Impostazioni</string>
     <string name="did_you_mean">"Intendevi: "</string>
     <string name="search_page">"Cerca pagina: "</string>
-    <string name="share_dialog_title">Condividi con:</string>
-    <string name="choose_browser">Scegli browser:</string>
+    <string name="share_dialog_title">Condividi con</string>
+    <string name="choose_browser">Scegli browser</string>
     <string name="screen_rotation">rotazione</string>
     <string name="settings_activity_title">Impostazioni</string>
     <string name="useExternalPlayerTitle">Usa un riproduttore video esterno</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -11,8 +11,8 @@
     <string name="settings">設定</string>
     <string name="did_you_mean">この意味ですか: %1$s ?</string>
     <string name="search_page">"検索ﾍﾟｰｼﾞ: "</string>
-    <string name="share_dialog_title">…共有:</string>
-    <string name="choose_browser">ﾌﾞﾗｳｻﾞｰを選択:</string>
+    <string name="share_dialog_title">…共有</string>
+    <string name="choose_browser">ﾌﾞﾗｳｻﾞｰを選択</string>
     <string name="screen_rotation">回転</string>
     <string name="settings_activity_title">設定</string>
     <string name="useExternalPlayerTitle">外部ﾌﾟﾚｰﾔｰを使用する</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -11,8 +11,8 @@
     <string name="settings">설정</string>
     <string name="did_you_mean">혹시 이것을 검색하셨습니까?: %1$s ?</string>
     <string name="search_page">"검색 페이지: "</string>
-    <string name="share_dialog_title">다음으로 공유:</string>
-    <string name="choose_browser">브라우저 선택:</string>
+    <string name="share_dialog_title">다음으로 공유</string>
+    <string name="choose_browser">브라우저 선택</string>
     <string name="screen_rotation">회전</string>
     <string name="settings_activity_title">설정</string>
     <string name="useExternalPlayerTitle">외부 플레이어 사용</string>
@@ -71,7 +71,7 @@
     <string name="err_dir_create">다운로드 디렉토리를 만들 수 없습니다 \'%1$s\'</string>
     <string name="info_dir_created">다운로드 디렉토리를 만들었습니다 \'%1$s\'</string>
 <string name="main_bg_subtitle">검색 버튼을 눌러서 시작하세요</string>
-    <string name="autoplay_by_calling_app_title">다른 앱에서 호출되었을 경우 자동 재생합니다.</string>
+    <string name="autoplay_by_calling_app_title">다른 앱에서 호출되었을 경우 자동 재생합니다</string>
     <string name="autoplay_by_calling_app_summary">NewPipe가 다른 앱으로부터 호출되었을 경우 비디오를 자동으로 재생합니다.</string>
     <string name="content">컨텐츠</string>
     <string name="show_age_restricted_content_title">나이 제한이 있는 컨텐츠를 표시</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -13,8 +13,8 @@
     <string name="settings">Innstillinger</string>
     <string name="did_you_mean">"Mente du: "</string>
     <string name="search_page">"Søk på siden: "</string>
-    <string name="share_dialog_title">Del med:</string>
-    <string name="choose_browser">Velg nettleser:</string>
+    <string name="share_dialog_title">Del med</string>
+    <string name="choose_browser">Velg nettleser</string>
     <string name="screen_rotation">sideoppsett</string>
     <string name="settings_activity_title">Innstillinger</string>
     <string name="use_external_video_player_title">Bruk ekstern videoavspiller</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -12,8 +12,8 @@
     <string name="settings">Instellingen</string>
     <string name="did_you_mean">Bedoelde je: %1$s ?</string>
     <string name="search_page">Zoekpagina: </string>
-    <string name="share_dialog_title">Delen met:</string>
-    <string name="choose_browser">Browser kiezen:</string>
+    <string name="share_dialog_title">Delen met</string>
+    <string name="choose_browser">Browser kiezen</string>
     <string name="screen_rotation">rotatie</string>
     <string name="settings_activity_title">Instellingen</string>
     <string name="useExternalPlayerTitle">Gebruik externe speler</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -11,8 +11,8 @@
     <string name="settings">Definições</string>
     <string name="did_you_mean">Será que queria dizer: %1$s?</string>
     <string name="search_page">"Página de pesquisa: "</string>
-    <string name="share_dialog_title">Partilhar com:</string>
-    <string name="choose_browser">Escolher navegador:</string>
+    <string name="share_dialog_title">Partilhar com</string>
+    <string name="choose_browser">Escolher navegador</string>
     <string name="screen_rotation">rotação</string>
     <string name="settings_activity_title">Definições</string>
     <string name="use_external_video_player_title">Utilizar reprodutor de vídeo externo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -13,8 +13,8 @@
     <string name="settings">Setări</string>
     <string name="did_you_mean">"V-ați referit la: "</string>
     <string name="search_page">"Pagina de căutare: "</string>
-    <string name="share_dialog_title">Partajează cu:</string>
-    <string name="choose_browser">Alegeți browser-ul:</string>
+    <string name="share_dialog_title">Partajează cu</string>
+    <string name="choose_browser">Alegeți browser-ul</string>
     <string name="screen_rotation">rotație</string>
     <string name="settings_activity_title">Setări</string>
     <string name="use_external_video_player_title">Folosește un player video extern</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -12,8 +12,8 @@
     <string name="settings">Настройки</string>
     <string name="did_you_mean">Возможно, вы имели в виду: </string>
     <string name="search_page">Страница поиска: </string>
-    <string name="share_dialog_title">Поделиться с помощью:</string>
-    <string name="choose_browser">Выбрать браузер:</string>
+    <string name="share_dialog_title">Поделиться с помощью</string>
+    <string name="choose_browser">Выбрать браузер</string>
     <string name="screen_rotation">поворот</string>
     <string name="settings_activity_title">Настройки</string>
     <string name="useExternalPlayerTitle">Использовать внешний проигрыватель</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -13,8 +13,8 @@
     <string name="settings">Nastavenia</string>
     <string name="did_you_mean">Mysleli ste: %1$s?</string>
     <string name="search_page">"Hľadať stránku: "</string>
-    <string name="share_dialog_title">Zdieľať s:</string>
-    <string name="choose_browser">Vyberte prehliadač:</string>
+    <string name="share_dialog_title">Zdieľať s</string>
+    <string name="choose_browser">Vyberte prehliadač</string>
     <string name="screen_rotation">otočenie</string>
     <string name="settings_activity_title">Nastavenia</string>
     <string name="use_external_video_player_title">Použiť externý prehrávač videa</string>
@@ -73,7 +73,7 @@
     <string name="err_dir_create">Nemožno vytvoriť adresár na preberanie \'%1$s\'</string>
     <string name="info_dir_created">Adresár na preberanie bol vytvorený \'%1$s\'</string>
 <string name="main_bg_subtitle">Začnite vyhľadaním obsahu</string>
-    <string name="autoplay_by_calling_app_title">Automaticky prehrať video pri zavolaní.</string>
+    <string name="autoplay_by_calling_app_title">Automaticky prehrať video pri zavolaní</string>
     <string name="autoplay_by_calling_app_summary">Video bude automaticky prehrané pri zavolaní NewPipe inou aplikáciou.</string>
     <string name="content">Obsah</string>
     <string name="show_age_restricted_content_title">Zobraziť vekovo obmedzený obsah</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -11,8 +11,8 @@
     <string name="settings">Nastavitve</string>
     <string name="did_you_mean">Ali ste mislili: %1$s?</string>
     <string name="search_page">"Stran iskanja: "</string>
-    <string name="share_dialog_title">Omogoči souporabo z:</string>
-    <string name="choose_browser">Izbor brskalnika:</string>
+    <string name="share_dialog_title">Omogoči souporabo z</string>
+    <string name="choose_browser">Izbor brskalnika</string>
     <string name="screen_rotation">usmerjenost</string>
     <string name="settings_activity_title">Nastavitve</string>
     <string name="use_external_video_player_title">Uporabi zunanji predvajalnik videa</string>
@@ -118,7 +118,7 @@
     <string name="error_querying_decoders">Ni mogoče preiskati dekodirnikov na napravi</string>
     <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_instantiating_decoder">Ni mogoče začeti dekodirnika <xliff:g id="decoder_name">%1$s</xliff:g></string>
     <string name="storage_permission_denied">Dovoljenje za dostop do shrambe je zavrnjeno</string>
-    <string name="autoplay_by_calling_app_title">Samodejno predvajaj vsebino, poslano iz drugega programa.</string>
+    <string name="autoplay_by_calling_app_title">Samodejno predvajaj vsebino, poslano iz drugega programa</string>
     <string name="autoplay_by_calling_app_summary">Samodejno predvajaj vsebino, če je NewPipe klican iz drugega programa.</string>
     <string name="report_error">Pošlji poročilo o napaki</string>
     <string name="user_report">Poročilo uporabnika</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -12,8 +12,8 @@
     <string name="settings">Поставке</string>
     <string name="did_you_mean">Да ли сте мислили: %1$s ?</string>
     <string name="search_page">Страница претраге: </string>
-    <string name="share_dialog_title">Подели помоћу:</string>
-    <string name="choose_browser">Отвори помоћу:</string>
+    <string name="share_dialog_title">Подели помоћу</string>
+    <string name="choose_browser">Отвори помоћу</string>
     <string name="screen_rotation">ротација</string>
     <string name="settings_activity_title">Поставке</string>
     <string name="useExternalPlayerTitle">Користи спољашњи плејер</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -13,8 +13,8 @@
     <string name="settings">Налаштування</string>
     <string name="did_you_mean">Ви мали на увазі: %1$s ?</string>
     <string name="search_page">"Пошукова сторінка: "</string>
-    <string name="share_dialog_title">Поділитись з:</string>
-    <string name="choose_browser">Виберіть браузер:</string>
+    <string name="share_dialog_title">Поділитись з</string>
+    <string name="choose_browser">Виберіть браузер</string>
     <string name="screen_rotation">обертання</string>
     <string name="settings_activity_title">Налаштування</string>
     <string name="use_external_video_player_title">Використовувати зовнішній відео програвач</string>
@@ -28,7 +28,7 @@
     <string name="download_path_summary">Шлях де будуть зберігатись завантажені відео.</string>
     <string name="download_path_audio_title">Шлях для завантаження аудіо</string>
     <string name="download_path_audio_summary">Шлях де будуть зберігатись завантажені аудіо файли.</string>
-    <string name="autoplay_by_calling_app_title">Автоматично відтворювати при виклику з іншого додатку.</string>
+    <string name="autoplay_by_calling_app_title">Автоматично відтворювати при виклику з іншого додатку</string>
     <string name="autoplay_by_calling_app_summary">Автоматично відтворювати відео коли NewPipe викликано з іншого додатку.</string>
     <string name="default_resolution_title">Роздільна здатність за замовчуванням</string>
     <string name="play_with_kodi_title">Відтворювати за допомогою Kodi</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -13,8 +13,8 @@
     <string name="settings">设置</string>
     <string name="did_you_mean">您是不是要找：</string>
     <string name="search_page">"搜索页面： "</string>
-    <string name="share_dialog_title">分享视频：</string>
-    <string name="choose_browser">选择浏览器：</string>
+    <string name="share_dialog_title">分享视频</string>
+    <string name="choose_browser">选择浏览器</string>
     <string name="screen_rotation">旋转</string>
     <string name="settings_activity_title">设置</string>
     <string name="use_external_video_player_title">使用外置视频播放器</string>
@@ -111,7 +111,7 @@
     <string name="storage_permission_denied">访问存储的权限被拒绝</string>
     <string name="use_exoplayer_summary">实验性</string>
 <string name="use_exoplayer_title">使用 ExoPlayer</string>
-    <string name="autoplay_by_calling_app_title">另一应用调用时自动播放。</string>
+    <string name="autoplay_by_calling_app_title">另一应用调用时自动播放</string>
     <string name="autoplay_by_calling_app_summary">NewPipe 是被另一应用调用时自动开始播放视频。</string>
     <string name="duration_live">直播</string>
 

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -9,7 +9,7 @@
     <string name="settings">設置</string>
     <string name="did_you_mean">"您是不是要查： "</string>
     <string name="search_page">"搜尋頁面： "</string>
-    <string name="choose_browser">選擇瀏覽器：</string>
+    <string name="choose_browser">選擇瀏覽器</string>
     <string name="screen_rotation">旋轉</string>
     <string name="settings_activity_title">設置</string>
     <string name="use_external_video_player_title">使用外置影片播放器</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -13,8 +13,8 @@
     <string name="settings">設定</string>
     <string name="did_you_mean">"您是不是要查： "</string>
     <string name="search_page">"搜尋頁面： "</string>
-    <string name="share_dialog_title">分享影片：</string>
-    <string name="choose_browser">選擇瀏覽器：</string>
+    <string name="share_dialog_title">分享影片</string>
+    <string name="choose_browser">選擇瀏覽器</string>
     <string name="screen_rotation">旋轉</string>
     <string name="settings_activity_title">設定</string>
     <string name="use_external_video_player_title">使用外置影片播放器</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,7 +67,7 @@
     <string name="show_next_and_similar_title">Show next and similar videos</string>
     <string name="url_not_supported_toast">URL not supported</string>
     <string name="similar_videos_btn_text">Similar videos</string>
-    <string name="search_language_title">Preferable content language</string>
+    <string name="search_language_title">Preferred content language</string>
     <string name="settings_category_video_audio_title">Video &amp; Audio</string>
     <string name="settings_category_appearance_title">Appearance</string>
     <string name="settings_category_other_title">Other</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,11 +25,11 @@
     <string name="use_external_video_player_title">Use external video player</string>
     <string name="use_external_audio_player_title">Use external audio player</string>
 
-    <string name="download_path_title">Download path video</string>
+    <string name="download_path_title">Video download path</string>
     <string name="download_path_summary">Path to store downloaded videos in.</string>
     <string name="download_path_dialog_title">Enter download path for videos</string>
 
-    <string name="download_path_audio_title">Download path audio</string>
+    <string name="download_path_audio_title">Audio download path</string>
     <string name="download_path_audio_summary">Path to store downloaded audio in.</string>
     <string name="download_path_audio_dialog_title">Enter download path for audio files.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
 
     <string name="autoplay_by_calling_app_title">Autoplay when called from another app</string>
     <string name="autoplay_by_calling_app_summary">Automatically play a video when NewPipe is called from another app.</string>
-    <string name="default_resolution_title">Default Resolution</string>
+    <string name="default_resolution_title">Default resolution</string>
     <string name="play_with_kodi_title">Play with Kodi</string>
     <string name="kore_not_found">Kore app not found. Install Kore?</string>
     <string name="fdroid_kore_url" translatable="false">https://f-droid.org/repository/browse/?fdfilter=Kore&amp;fdid=org.xbmc.kore</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,8 +18,8 @@
     <string name="settings">Settings</string>
     <string name="did_you_mean">Did you mean: %1$s ?</string>
     <string name="search_page">Search page: </string>
-    <string name="share_dialog_title">Share with:</string>
-    <string name="choose_browser">Choose browser:</string>
+    <string name="share_dialog_title">Share with</string>
+    <string name="choose_browser">Choose browser</string>
     <string name="screen_rotation">rotation</string>
     <string name="settings_activity_title">Settings</string>
     <string name="use_external_video_player_title">Use external video player</string>
@@ -33,7 +33,7 @@
     <string name="download_path_audio_summary">Path to store downloaded audio in.</string>
     <string name="download_path_audio_dialog_title">Enter download path for audio files.</string>
 
-    <string name="autoplay_by_calling_app_title">Autoplay when called from another app.</string>
+    <string name="autoplay_by_calling_app_title">Autoplay when called from another app</string>
     <string name="autoplay_by_calling_app_summary">Automatically play a video when NewPipe is called from another app.</string>
     <string name="default_resolution_title">Default Resolution</string>
     <string name="play_with_kodi_title">Play with Kodi</string>


### PR DESCRIPTION
The following 4 commits fix common mistakes in the UI strings:

### `98afe79` strings.xml: Remove unnecessary punctuations
Periods, colons and other unnecessary punctuations should not be used in labels.
See https://www.google.com/design/spec/style/writing.html#writing-capitalization-punctuation

### `2a6e7f3` search_language_title: Change "Preferable" to "Preferred"
Why? See http://english.stackexchange.com/questions/128996/how-would-one-know-when-to-choose-preferred-or-preferable

### `8060c6a` strings.xml: Fix grammar
"Download path video" -> "Video download path"
"Download path audio" -> "Audio download path"

### `a5fc6db` default_resolution_title: Fix capitalization
"Default Resolution" -> "Default resolution"

See https://www.google.com/design/spec/style/writing.html#writing-capitalization-punctuation

#### OCD...
![It has been fixed!](http://img.ifcdn.com/images/7ced8b09d25705ddb44fa2efb43431b51c972e4f53aa9beb4a1362675b124654_3.jpg)