### PR TITLE
Disable/Enable downloading videos/audio over mobile networks

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -7,7 +7,9 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.DialogFragment;
@@ -181,6 +183,33 @@ public class DownloadDialog extends DialogFragment {
                     Uri.parse(url));
             request.setDestinationUri(Uri.fromFile(saveFilePath));
             request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+
+            //Check if download over mobile network is allowed
+            if (PreferenceManager.getDefaultSharedPreferences(context)
+                    .getBoolean(context.getString(R.string.download_mobile), false)){
+                Toast.makeText(this.getActivity(),R.string.warning_download_mobile , Toast.LENGTH_LONG).show();
+
+                request.setAllowedNetworkTypes(DownloadManager.Request.NETWORK_MOBILE); //allow mobile network
+                request.setAllowedNetworkTypes(DownloadManager.Request.NETWORK_WIFI);   //allow wifi
+                request.setAllowedOverRoaming(true);                                    //allow roaming
+
+                if (Build.VERSION.SDK_INT >= 16){
+                    request.setAllowedOverMetered(true);                            //Set counted/metered Netowrk as allowed
+                }
+
+            } else {
+                request.setAllowedNetworkTypes(DownloadManager.Request.NETWORK_WIFI);//enabel wifi
+                request.setAllowedOverRoaming(false);                                //disable roaming
+                if (Build.VERSION.SDK_INT >= 16){
+                    request.setAllowedOverMetered(false);                            //Set counted/metered Netowrk as allowed
+                }
+            }
+
+            /*
+            if (mna) {
+
+            }
+            */
 
             request.setTitle(title);
             request.setDescription("'" + url +

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -200,16 +200,10 @@ public class DownloadDialog extends DialogFragment {
             } else {
                 request.setAllowedNetworkTypes(DownloadManager.Request.NETWORK_WIFI);//enabel wifi
                 request.setAllowedOverRoaming(false);                                //disable roaming
-                if (Build.VERSION.SDK_INT >= 16){
+                if (Build.VERSION.SDK_INT >= 16) {
                     request.setAllowedOverMetered(false);                            //Set counted/metered Netowrk as allowed
                 }
             }
-
-            /*
-            if (mna) {
-
-            }
-            */
 
             request.setTitle(title);
             request.setDescription("'" + url +

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -211,4 +211,5 @@
     </string-array>
     <string name="show_age_restricted_content">show_age_restricted_content</string>
     <string name="use_tor_key">use_tor</string>
+    <string name="download_mobile">download_mobile</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,7 +62,7 @@
     <string-array name="download_options_no_video">
         <item>Audio</item>
     </string-array>
-    <string name="warning_download_mobile">Mobile Download is allowed</string>
+    <string name="warning_download_mobile">Mobile Download is enabled</string>
 
     <string name="next_video_title">Next video</string>
     <string name="show_next_and_similar_title">Show next and similar videos</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
     <string-array name="download_options_no_video">
         <item>Audio</item>
     </string-array>
+    <string name="warning_download_mobile">Mobile Download is allowed</string>
 
     <string name="next_video_title">Next video</string>
     <string name="show_next_and_similar_title">Show next and similar videos</string>
@@ -140,4 +141,7 @@
     <string name="storage_permission_denied">Permission to access storage was denied</string>
     <string name="use_exoplayer_title">Use ExoPlayer</string>
     <string name="use_exoplayer_summary">Experimental</string>
+
+    <string name="download_roming_title">Mobile Downloads</string>
+    <string name="download_roming_summary">Allow the Application to download Videos/Audio over the Mobile Network</string>
 </resources>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -116,5 +116,11 @@
             android:summary="@string/use_tor_summary"
             android:defaultValue="false"/>
 
+        <CheckBoxPreference
+            android:key="@string/download_mobile"
+            android:title="@string/download_roming_title"
+            android:summary="@string/download_roming_summary"
+            android:defaultValue="false" />
+
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
I have added a new Setting "Mobile Downloads". If you allow this you will be able to download videos or audio with the mobile network, roaming and metered (counted) network, if you disable (default) is it will download it only over the wifi. A lite feature for #247. Not complete, but a part ...