### PR TITLE
Fix to hide uploader correctly

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/VideoInfoItemViewCreator.java
+++ b/app/src/main/java/org/schabi/newpipe/VideoInfoItemViewCreator.java
@@ -6,11 +6,11 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import org.schabi.newpipe.extractor.AbstractVideoInfo;
-import org.schabi.newpipe.extractor.StreamPreviewInfo;
-
 import com.nostra13.universalimageloader.core.DisplayImageOptions;
 import com.nostra13.universalimageloader.core.ImageLoader;
+
+import org.schabi.newpipe.extractor.AbstractVideoInfo;
+import org.schabi.newpipe.extractor.StreamPreviewInfo;
 
 /**
  * Created by Christian Schabesberger on 24.10.15.
@@ -72,7 +72,7 @@ public class VideoInfoItemViewCreator {
         if(info.uploader != null && !info.uploader.isEmpty()) {
             holder.itemUploaderView.setText(info.uploader);
         } else {
-            holder.itemDurationView.setVisibility(View.INVISIBLE);
+            holder.itemUploaderView.setVisibility(View.INVISIBLE);
         }
         if(info.duration > 0) {
             holder.itemDurationView.setText(getDurationString(info.duration));


### PR DESCRIPTION
Hi,

The bug will not surface itself as we have an up-loader all the times, but it indeed is a bug as we were hiding itemDurationView when itemUploaderView was empty. 