### PR TITLE
Upgrade gradle wrapper to 2.10

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="view_count_text">%1$s Aufrufe</string>
     <string name="upload_date_text">Veröffentlicht am %1$s</string>
     <string name="no_player_found">Keinen Streamplayer gefunden. Möchtest du VLC installieren?</string>
@@ -106,18 +106,18 @@
     <string name="error_drm_unsupported_scheme">Dieses Gerät unterstützt das erforderliche DRM-Schema nicht</string>
     <string name="error_drm_unknown">Ein unbekannter DRM-Fehler ist aufgetreten</string>
     <string name="error_querying_decoders">Konnte Dekodierer des Gerätes nicht abrufen</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_instantiating_decoder">Konnte Dekodierer <xliff:g id="decoder_name">%1$s</xliff:g> nicht instantiieren</string>
+    <string name="error_instantiating_decoder">Konnte Dekodierer <xliff:g id="decoder_name">%1$s</xliff:g> nicht instantiieren</string>
     <string name="storage_permission_denied">Zugriff auf den Massenspeicher wurde verweigert</string>
     <string name="use_exoplayer_title">Benutze ExoPlayer</string>
     <string name="use_exoplayer_summary">Experimentell</string>
-<string name="sorry_string">Entschuldigung. Dies sollte nicht passieren.</string>
+    <string name="sorry_string">Entschuldigung. Dies sollte nicht passieren.</string>
     <string name="error_snackbar_message">Entschuldigung. Es sind einige Fehler aufgetreten.</string>
     <string name="info_searched_lbl">Gesucht:</string>
     <string name="info_requested_stream_lbl">Angeforderter Stream:</string>
     <string name="your_comment">Dein Kommentar (auf englisch):</string>
     <string name="logging">Protokollierung</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">Dieses Gerät stellt keinen Dekodierer für <xliff:g id="mime_type">%1$s</xliff:g> bereit</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">Dieses Gerät stellt keinen abgesicherten Dekodierer für <xliff:g id="mime_type">%1$s</xliff:g> bereit</string>
+    <string name="error_no_decoder">Dieses Gerät stellt keinen Dekodierer für <xliff:g id="mime_type">%1$s</xliff:g> bereit</string>
+    <string name="error_no_secure_decoder">Dieses Gerät stellt keinen abgesicherten Dekodierer für <xliff:g id="mime_type">%1$s</xliff:g> bereit</string>
     <string name="could_not_get_stream">Konnte keinen Stream holen.</string>
     <string name="error_drm_not_supported">Geschützte Inhalte werden von API-Ebenen unterhalb von 18 nicht unterstützt</string>
     <string name="autoplay_by_calling_app_title">Bei Aufruf aus einer anderen App automatisch abspielen</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="autoplay_through_intent_summary">Lire automatiquement une vidéo lorsqu’elle a été appelée depuis une autre application.</string>
     <string name="cancel">Annuler</string>
     <string name="choose_browser">Choisir un navigateur </string>
@@ -112,9 +112,9 @@
 
     <string name="logging">Connexion</string>
     <string name="error_drm_not_supported">Contenu protégé non supporté par l\'API antérieure à la version 18</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">Cet appareil ne fournit pas de décodeur pour <xliff:g id="mime_type">%1$s</xliff:g></string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">Cet appareil ne fournit pas de décodeur sécurisé pour <xliff:g id="mime_type">%1$s</xliff:g></string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_instantiating_decoder">Impossible d\'instancier le décodeur <xliff:g id="decoder_name">%1$s</xliff:g></string>
+    <string name="error_no_decoder">Cet appareil ne fournit pas de décodeur pour <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_secure_decoder">Cet appareil ne fournit pas de décodeur sécurisé pour <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_instantiating_decoder">Impossible d\'instancier le décodeur <xliff:g id="decoder_name">%1$s</xliff:g></string>
     <string name="error_snackbar_action">SIGNALER</string>
     <string name="could_not_setup_download_menu">de téléchargement.</string>
     <string name="could_not_get_stream">Impossible d\'obtenir une diffusion.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="view_count_text">%1$s megtekintés</string>
     <string name="upload_date_text">Közzétéve: %1$s</string>
     <string name="no_player_found">Nem található megfelelő lejátszó. Feltelepíti a VLC lejátszót?</string>
@@ -121,7 +121,7 @@
     <string name="error_drm_not_supported">Védett tartalom, 18 alatt nem támogatott API szinteken</string>
     <string name="error_drm_unsupported_scheme">Ez az eszköz nem támogatja a szükséges DRM sémát</string>
     <string name="logging">Naplózás</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">Ez az eszköz nem rendelkezik dekóderrel a következőhöz: <xliff:g id="mime_type">%1$s</xliff:g></string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">Ez az eszköz nem rendelkezik biztonságos dekóderrel a következőhöz: <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_decoder">Ez az eszköz nem rendelkezik dekóderrel a következőhöz: <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_secure_decoder">Ez az eszköz nem rendelkezik biztonságos dekóderrel a következőhöz: <xliff:g id="mime_type">%1$s</xliff:g></string>
     <string name="error_querying_decoders">Nem lehet lekérdezni az eszköz dekódereit</string>
     </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources><string name="view_count_text">%1$s visite</string>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="view_count_text">%1$s visite</string>
     <string name="upload_date_text">Pubblicato il %1$s</string>
     <string name="no_player_found">Nessun riproduttore trovato. Vuoi installare VLC?</string>
     <string name="install">Installa</string>
@@ -121,10 +122,10 @@
     <string name="error_drm_not_supported">Il contenuto protetto non è supportato nelle API precedenti al livello 18</string>
     <string name="error_drm_unsupported_scheme">Questo dispositivo non supporta lo schema DRM richiesto</string>
     <string name="error_drm_unknown">Si è verificato un errore sconosciuto con il DRM</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">Questo dispositivo non è fornito di un decoder per <xliff:g id="mime_type">%1$s</xliff:g></string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">Questo dispositivo non è fornito di un decoder sicuro per <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_decoder">Questo dispositivo non è fornito di un decoder per <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_secure_decoder">Questo dispositivo non è fornito di un decoder sicuro per <xliff:g id="mime_type">%1$s</xliff:g></string>
     <string name="error_querying_decoders">Impossibile ottenere informazioni sui decoder del dispositivo</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_instantiating_decoder">Impossibile creare un\'istanza del decoder <xliff:g id="decoder_name">%1$s</xliff:g></string>
+    <string name="error_instantiating_decoder">Impossibile creare un\'istanza del decoder <xliff:g id="decoder_name">%1$s</xliff:g></string>
     <string name="storage_permission_denied">È stato negato il permesso di accedere all\'archiviazione di massa</string>
     <string name="use_exoplayer_title">Usa ExoPlayer</string>
     <string name="use_exoplayer_summary">Sperimentale</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="upload_date_text">%1$s に公開</string>
     <string name="no_player_found">ｽﾄﾘｰﾑのﾌﾟﾚｲﾔｰが見つかりません｡VLC をｲﾝｽﾄｰﾙしますか?</string>
     <string name="install">ｲﾝｽﾄｰﾙ</string>
@@ -112,10 +112,10 @@
     <string name="error_drm_not_supported">保護されたコンテンツは API レベル 18 未満でサポートされていません</string>
     <string name="error_drm_unsupported_scheme">このデバイスは必要な DRM スキームをサポートしません</string>
     <string name="error_drm_unknown">不明な DRM エラーが発生しました</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">このデバイスは <xliff:g id="mime_type">%1$s</xliff:g> のデコーダーが提供されていません</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">このデバイスは <xliff:g id="mime_type">%1$s</xliff:g> のセキュア デコーダーが提供されていません</string>
+    <string name="error_no_decoder">このデバイスは <xliff:g id="mime_type">%1$s</xliff:g> のデコーダーが提供されていません</string>
+    <string name="error_no_secure_decoder">このデバイスは <xliff:g id="mime_type">%1$s</xliff:g> のセキュア デコーダーが提供されていません</string>
     <string name="error_querying_decoders">デバイスのデコーダーを問い合わせできません</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_instantiating_decoder">デコーダー <xliff:g id="decoder_name">%1$s</xliff:g> をインスタンス化できません</string>
+    <string name="error_instantiating_decoder">デコーダー <xliff:g id="decoder_name">%1$s</xliff:g> をインスタンス化できません</string>
     <string name="storage_permission_denied">ストレージにアクセスするアクセス許可が拒否されました</string>
     <string name="use_exoplayer_title">ExoPlayer を使用する</string>
     <string name="use_exoplayer_summary">実験的</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources><string name="view_count_text">시청 횟수 %1$s</string>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="view_count_text">시청 횟수 %1$s</string>
     <string name="upload_date_text">%1$s에 업로드됨</string>
     <string name="no_player_found">스트리밍 플레이어가 발견되지 않았습니다. VLC를 설치할까요?</string>
     <string name="install">설치</string>
@@ -116,10 +117,10 @@
     <string name="error_drm_not_supported">보호된 컨텐츠는 API 18 이하에서는 지원되지 않습니다</string>
     <string name="error_drm_unsupported_scheme">이 기기는 요구되는 DRM 스킴을 지원하지 않습니다</string>
     <string name="error_drm_unknown">알 수 없는 DRM 오류가 발생했습니다</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">이 기기는 다음을 위한 디코더를 지원하지 않습니다: <xliff:g id="mime_type">%1$s</xliff:g></string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">이 기기는 다음을 위한 보안 디코더를 지원하지 않습니다: <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_decoder">이 기기는 다음을 위한 디코더를 지원하지 않습니다: <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_secure_decoder">이 기기는 다음을 위한 보안 디코더를 지원하지 않습니다: <xliff:g id="mime_type">%1$s</xliff:g></string>
     <string name="error_querying_decoders">기기의 디코더를 요청할 수 없습니다</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_instantiating_decoder">다음 디코더를 참조할 수 없습니다: <xliff:g id="decoder_name">%1$s</xliff:g></string>
+    <string name="error_instantiating_decoder">다음 디코더를 참조할 수 없습니다: <xliff:g id="decoder_name">%1$s</xliff:g></string>
     <string name="storage_permission_denied">저장소에 접근할 권한이 거부되었습니다</string>
     <string name="use_exoplayer_title">ExoPlayer 사용</string>
     <string name="use_exoplayer_summary">실험적</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources><string name="background_player_name">NewPipe bakgrunnsavspiller</string>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2"><string name="background_player_name">NewPipe bakgrunnsavspiller</string>
     <string name="view_count_text">%1$s visninger</string>
     <string name="upload_date_text">Opplastet den %1$s</string>
     <string name="no_player_found">Fant ingen videostrøm. Installer VLC?</string>
@@ -109,14 +109,14 @@
     <string name="error_drm_not_supported">Beskyttet innhold støttes ikke på API-nivåer under 18</string>
     <string name="error_drm_unsupported_scheme">Denne enheten støtter ikke påkrevd DRM-anordning</string>
     <string name="error_drm_unknown">En ukjent DRM-feil inntraff</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">Denne enheten mangler dekoder for <xliff:g id="mime_type">%1$s</xliff:g></string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">Denne enheten mangler sikker dekoder for <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_decoder">Denne enheten mangler dekoder for <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_secure_decoder">Denne enheten mangler sikker dekoder for <xliff:g id="mime_type">%1$s</xliff:g></string>
     <string name="error_querying_decoders">Kunne ikke sjekke enhetens dekodere</string>
     <string name="storage_permission_denied">Tilgang til lagring nektet</string>
     <string name="use_exoplayer_title">Bruk ExoPlayer</string>
     <string name="use_exoplayer_summary">Eksperimentelt</string>
-<string name="duration_live">direkteoverført</string>
+    <string name="duration_live">direkteoverført</string>
 
     <string name="info_labels">Hva:\\nRequest:\\nContent Språk:\\nService:\\nGMT Tid:\\nVersion:\\nOS version:\\nGlob. IP-blokk:</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_instantiating_decoder">Kunne ikke igangsette dekoder <xliff:g id="decoder_name">%1$s</xliff:g></string>
+    <string name="error_instantiating_decoder">Kunne ikke igangsette dekoder <xliff:g id="decoder_name">%1$s</xliff:g></string>
     </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="view_count_text">%1$s keer bekeken</string>
     <string name="upload_date_text">Geüpload op %1$s</string>
     <string name="no_player_found">Geen speler met streamondersteuning gevonden. Wil je VLC installeren?</string>
@@ -107,7 +107,7 @@
     <string name="error_drm_not_supported">Beschermde inhoud niet ondersteunt op API versies lager dan 18</string>
     <string name="error_drm_unsupported_scheme">Dit apparaat ondersteunt niet het vereiste DRM-schema</string>
     <string name="error_drm_unknown">Een onbekende DRM-fout heeft zich voorgedaan</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">Dit apparaat heeft geen decoder voor <xliff:g id="mime_type"> 1%1$s</xliff:g> 2</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">Dit apparaat heeft geen veilige decoder voor<xliff:g id="mime_type"> 1%1$s</xliff:g></string>
+    <string name="error_no_decoder">Dit apparaat heeft geen decoder voor <xliff:g id="mime_type"> 1%1$s</xliff:g> 2</string>
+    <string name="error_no_secure_decoder">Dit apparaat heeft geen veilige decoder voor<xliff:g id="mime_type"> 1%1$s</xliff:g></string>
     <string name="error_querying_decoders">Kon apparaatdecoders niet ophalen</string>
     </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources><string name="view_count_text">%1$s visualizações</string>
+<resources  xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="view_count_text">%1$s visualizações</string>
     <string name="upload_date_text">Publicado em %1$s</string>
     <string name="no_player_found">Reprodutor não disponível. Instalar o VLC?</string>
     <string name="install">Instalar</string>
@@ -107,14 +108,14 @@
     <string name="error_drm_not_supported">O conteúdo protegido não é permitido em API com nível inferior a 18</string>
     <string name="error_drm_unsupported_scheme">Este dispositivo não tem suporte ao esquema DRM necessário</string>
     <string name="error_drm_unknown">Ocorreu um erro de DRM desconhecido</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">Este dispositivo não disponibiliza um descodificador para <xliff:g id="mime_type">%1$s</xliff:g></string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">Este dispositivo não disponibiliza um descodificador seguro para <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_decoder">Este dispositivo não disponibiliza um descodificador para <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_secure_decoder">Este dispositivo não disponibiliza um descodificador seguro para <xliff:g id="mime_type">%1$s</xliff:g></string>
     <string name="error_querying_decoders">Incapaz de processar os descodificadores</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_instantiating_decoder">Incapaz de iniciar o descodificador <xliff:g id="decoder_name">%1$s</xliff:g></string>
+    <string name="error_instantiating_decoder">Incapaz de iniciar o descodificador <xliff:g id="decoder_name">%1$s</xliff:g></string>
     <string name="storage_permission_denied">Não foi concedida permissão para aceder ao armazenamento</string>
     <string name="use_exoplayer_title">Usar ExoPlayer</string>
     <string name="use_exoplayer_summary">Experimental</string>
-<string name="main_bg_subtitle">Toque para iniciar a pesquisa</string>
+    <string name="main_bg_subtitle">Toque para iniciar a pesquisa</string>
     <string name="autoplay_by_calling_app_title">Reproduzir se invocado por outra aplicação</string>
     <string name="autoplay_by_calling_app_summary">Reproduzir vídeo automaticamente se o NewPipe for invocado por outra aplicação.</string>
     <string name="duration_live">direto</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources><string name="background_player_name">NewPipe Prehrávač na pozadí</string>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="background_player_name">NewPipe Prehrávač na pozadí</string>
     <string name="view_count_text">%1$s pozretí</string>
     <string name="upload_date_text">Zverejnené %1$s</string>
     <string name="no_player_found">Nenašiel sa prehrávač. Nainštalovať VLC?</string>
@@ -112,10 +113,10 @@
     <string name="error_drm_not_supported">Chránený obsah nie je podporovaný cez API úrovne pod 18</string>
     <string name="error_drm_unsupported_scheme">Toto zariadenie nepodporuje požadovanú DRM schému</string>
     <string name="error_drm_unknown">Nastala neznáma chyba DRM</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">Toto zariadenie nemá dekóder pre <xliff:g id="mime_type">%1$s</xliff:g></string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">Toto zariadenie nemá zabezpečený dekóder pre <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_decoder">Toto zariadenie nemá dekóder pre <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_secure_decoder">Toto zariadenie nemá zabezpečený dekóder pre <xliff:g id="mime_type">%1$s</xliff:g></string>
     <string name="error_querying_decoders">Nemožno zavolať dekódery zariadenia</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_instantiating_decoder">Nemožno vytvoriť inštanciu dekódera <xliff:g id="decoder_name">%1$s</xliff:g></string>
+    <string name="error_instantiating_decoder">Nemožno vytvoriť inštanciu dekódera <xliff:g id="decoder_name">%1$s</xliff:g></string>
     <string name="storage_permission_denied">Prístup na úložisko bol zakázaný</string>
     <string name="use_exoplayer_title">Použit ExoPlayer</string>
     <string name="use_exoplayer_summary">Experimentálne</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources><string name="view_count_text">%1$s pogledov</string>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="view_count_text">%1$s pogledov</string>
     <string name="upload_date_text">Objavljeno %1$s</string>
     <string name="no_player_found">Predvajalnika pretoka ni mogoče najti. Ali želite namestiti program VLC?</string>
     <string name="install">Namesti</string>
@@ -113,10 +114,10 @@
     <string name="error_drm_not_supported">Zaščitena vsebina na ravneh API pod 18 ni podprta</string>
     <string name="error_drm_unsupported_scheme">Ta naprava ne podpira zahtevane sheme DRM</string>
     <string name="error_drm_unknown">Prišlo je do neznane napake DRM</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">Na napravi ni nameščenega dekodirnika vrste <xliff:g id="mime_type">%1$s</xliff:g></string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">Na napravi ni nameščenega varnega dekodirnika vrste <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_decoder">Na napravi ni nameščenega dekodirnika vrste <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_secure_decoder">Na napravi ni nameščenega varnega dekodirnika vrste <xliff:g id="mime_type">%1$s</xliff:g></string>
     <string name="error_querying_decoders">Ni mogoče preiskati dekodirnikov na napravi</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_instantiating_decoder">Ni mogoče začeti dekodirnika <xliff:g id="decoder_name">%1$s</xliff:g></string>
+    <string name="error_instantiating_decoder">Ni mogoče začeti dekodirnika <xliff:g id="decoder_name">%1$s</xliff:g></string>
     <string name="storage_permission_denied">Dovoljenje za dostop do shrambe je zavrnjeno</string>
     <string name="autoplay_by_calling_app_title">Samodejno predvajaj vsebino, poslano iz drugega programa</string>
     <string name="autoplay_by_calling_app_summary">Samodejno predvajaj vsebino, če je NewPipe klican iz drugega programa.</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="view_count_text">%1$s приказа</string>
     <string name="upload_date_text">Објављен %1$s</string>
     <string name="no_player_found">Нема плејера токова. Инсталирати ВЛЦ?</string>
@@ -116,10 +116,10 @@
     <string name="error_drm_not_supported">Заштићени садржај није подржани на издањима АПИ-ија испод 18</string>
     <string name="error_drm_unsupported_scheme">Овај уређај не подржава захтевану ДРМ шему</string>
     <string name="error_drm_unknown">Десила се непозната грешка ДРМ-а</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">Овај уређај не обезбеђује декодер за <xliff:g id="mime_type">%1$s</xliff:g></string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">Овај уређај не обезбеђује безбедни декодер за <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_decoder">Овај уређај не обезбеђује декодер за <xliff:g id="mime_type">%1$s</xliff:g></string>
+    <string name="error_no_secure_decoder">Овај уређај не обезбеђује безбедни декодер за <xliff:g id="mime_type">%1$s</xliff:g></string>
     <string name="error_querying_decoders">Не могох да потражим декодере уређаја</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_instantiating_decoder">Не могох да покренем декодер <xliff:g id="decoder_name">%1$s</xliff:g></string>
+    <string name="error_instantiating_decoder">Не могох да покренем декодер <xliff:g id="decoder_name">%1$s</xliff:g></string>
     <string name="storage_permission_denied">Дозвола за приступ складишту је одбијена</string>
     <string name="report_error">Пријавите грешку</string>
     <string name="user_report">Извештај корисника</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources><string name="background_player_name">NewPipe 背景播放器</string>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="background_player_name">NewPipe 背景播放器</string>
     <string name="view_count_text">%1$s 次观看</string>
     <string name="upload_date_text">于 %1$s 发布</string>
     <string name="no_player_found">找不到任何串流播放器。您是否要安装 VLC？</string>
@@ -104,10 +105,10 @@
     <string name="error_drm_not_supported">已保护内容在 API 级别低于 18 时不支持</string>
     <string name="error_drm_unsupported_scheme">此设备不支持 DRM 模式</string>
     <string name="error_drm_unknown">发生未知 DRM 错误</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">此设备未提供一个 <xliff:g id="mime_type">%1$s</xliff:g> 的解码器</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">此设备未提供一个 <xliff:g id="mime_type">%1$s</xliff:g> 的安全解码器</string>
+    <string name="error_no_decoder">此设备未提供一个 <xliff:g id="mime_type">%1$s</xliff:g> 的解码器</string>
+    <string name="error_no_secure_decoder">此设备未提供一个 <xliff:g id="mime_type">%1$s</xliff:g> 的安全解码器</string>
     <string name="error_querying_decoders">无法查询设备解码器</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_instantiating_decoder">无法实例化解码器 <xliff:g id="decoder_name">%1$s</xliff:g></string>
+    <string name="error_instantiating_decoder">无法实例化解码器 <xliff:g id="decoder_name">%1$s</xliff:g></string>
     <string name="storage_permission_denied">访问存储的权限被拒绝</string>
     <string name="use_exoplayer_summary">实验性</string>
 <string name="use_exoplayer_title">使用 ExoPlayer</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources><string name="install">安裝</string>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="install">安裝</string>
     <string name="cancel">取消</string>
     <string name="upload_date_text">於 %1$s 發佈</string>
     <string name="share">分享</string>
@@ -105,7 +106,7 @@
     <string name="off">[關閉]</string>
     <string name="error_drm_not_supported">API 等級低於 18 時並不支援顯示受保護的內容</string>
     <string name="error_drm_unknown">發生了不明的 DRM 錯誤</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_decoder">此裝置未能為 <xliff:g id="mime_type">%1$s</xliff:g> 提供解碼器</string>
-    <string xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" name="error_no_secure_decoder">此裝置未能為 <xliff:g id="mime_type">%1$s</xliff:g> 提供安全的解碼器</string>
+    <string name="error_no_decoder">此裝置未能為 <xliff:g id="mime_type">%1$s</xliff:g> 提供解碼器</string>
+    <string name="error_no_secure_decoder">此裝置未能為 <xliff:g id="mime_type">%1$s</xliff:g> 提供安全的解碼器</string>
     <string name="error_querying_decoders">無法尋找裝置解碼器</string>
     </resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
https://travis-ci.org/theScrabi/NewPipe indicate gradle 2.10 is required.

FAILURE: Build failed with an exception.
* Where:
Build file '/home/travis/build/theScrabi/NewPipe/app/build.gradle' line: 1
* What went wrong:
A problem occurred evaluating project ':app'.
> Failed to apply plugin [id 'com.android.application']
   > Gradle version 2.10 is required. Current version is 2.4. If using the gradle wrapper, try editing the distributionUrl in /home/travis/build/theScrabi/NewPipe/gradle/wrapper/gradle-wrapper.properties to gradle-2.10-all.zip