### PR TITLE
Code quality fix - Declarations should use Java collection interfaces such as "List" rather than specific implementation.

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/extractor/youtube/YoutubeSearchEngineTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/extractor/youtube/YoutubeSearchEngineTest.java
@@ -11,7 +11,7 @@ import org.schabi.newpipe.Downloader;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by Christian Schabesberger on 29.12.15.
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 
 public class YoutubeSearchEngineTest extends AndroidTestCase {
     private SearchResult result;
-    private ArrayList<String> suggestionReply;
+    private List<String> suggestionReply;
 
     @Override
     public void setUp() throws Exception{

--- a/app/src/main/java/org/schabi/newpipe/SuggestionListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/SuggestionListAdapter.java
@@ -10,6 +10,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by Madiyar on 23.02.2016.
@@ -59,7 +60,7 @@ public class SuggestionListAdapter extends CursorAdapter {
     }
 
 
-    public void updateAdapter(ArrayList<String> suggestions) {
+    public void updateAdapter(List<String> suggestions) {
         MatrixCursor cursor = new MatrixCursor(columns);
         int i = 0;
         for (String s : suggestions) {

--- a/app/src/main/java/org/schabi/newpipe/VideoItemListActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/VideoItemListActivity.java
@@ -25,7 +25,7 @@ import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.StreamingService;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 
 /**
@@ -143,9 +143,9 @@ public class VideoItemListActivity extends AppCompatActivity
 
     private class SuggestionResultRunnable implements Runnable{
 
-        private ArrayList<String>suggestions;
+        private List<String> suggestions;
 
-        private SuggestionResultRunnable(ArrayList<String> suggestions) {
+        private SuggestionResultRunnable(List<String> suggestions) {
             this.suggestions = suggestions;
         }
 
@@ -175,7 +175,7 @@ public class VideoItemListActivity extends AppCompatActivity
                 String searchLanguageKey = context.getString(R.string.search_language_key);
                 String searchLanguage = sp.getString(searchLanguageKey,
                         getString(R.string.default_language_value));
-                ArrayList<String>suggestions = engine.suggestionList(query,searchLanguage,new Downloader());
+                List<String> suggestions = engine.suggestionList(query,searchLanguage,new Downloader());
                 h.post(new SuggestionResultRunnable(suggestions));
             } catch (ExtractionException e) {
                 ErrorActivity.reportError(h, VideoItemListActivity.this, e, null, findViewById(R.id.videoitem_list),

--- a/app/src/main/java/org/schabi/newpipe/extractor/SearchEngine.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/SearchEngine.java
@@ -1,9 +1,7 @@
 package org.schabi.newpipe.extractor;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 /**
  * Created by Christian Schabesberger on 10.08.15.
@@ -43,7 +41,7 @@ public abstract class SearchEngine {
         return collector;
     }
 
-    public abstract ArrayList<String> suggestionList(
+    public abstract List<String> suggestionList(
             String query,String contentCountry, Downloader dl)
             throws ExtractionException, IOException;
 

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngine.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngine.java
@@ -22,6 +22,7 @@ import java.net.URLEncoder;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -130,10 +131,10 @@ public class YoutubeSearchEngine extends SearchEngine {
     }
 
     @Override
-    public ArrayList<String> suggestionList(String query, String contentCountry, Downloader dl)
+    public List<String> suggestionList(String query, String contentCountry, Downloader dl)
             throws IOException, ParsingException {
 
-        ArrayList<String> suggestions = new ArrayList<>();
+        List<String> suggestions = new ArrayList<>();
 
         /* Cant use Uri.Bilder since it's android code.
         // Android code is baned from the extractor side.

--- a/app/src/main/java/us/shandian/giga/get/DownloadMission.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadMission.java
@@ -12,6 +12,8 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import us.shandian.giga.util.Utility;
 import static org.schabi.newpipe.BuildConfig.DEBUG;
@@ -39,8 +41,8 @@ public class DownloadMission
 	public long done;
 	public int threadCount = 3;
 	public int finishCount;
-	public ArrayList<Long> threadPositions = new ArrayList<Long>();
-	public HashMap<Long, Boolean> blockState = new HashMap<Long, Boolean>();
+	public List<Long> threadPositions = new ArrayList<Long>();
+	public Map<Long, Boolean> blockState = new HashMap<Long, Boolean>();
 	public boolean running;
 	public boolean finished;
 	public boolean fallback;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319

Please let me know if you have any questions.

Faisal Hameed