### PR TITLE
Code quality fix - Redundant modifiers should not be used.

### DIFF
--- a/app/src/main/java/us/shandian/giga/get/DownloadManager.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadManager.java
@@ -2,13 +2,13 @@ package us.shandian.giga.get;
 
 public interface DownloadManager
 {
-	public static final int BLOCK_SIZE = 512 * 1024;
+	int BLOCK_SIZE = 512 * 1024;
 	
-	public int startMission(String url, String name, int threads);
-	public void resumeMission(int id);
-	public void pauseMission(int id);
-	public void deleteMission(int id);
-	public DownloadMission getMission(int id);
-	public int getCount();
-	public String getLocation();
+	int startMission(String url, String name, int threads);
+	void resumeMission(int id);
+	void pauseMission(int id);
+	void deleteMission(int id);
+	DownloadMission getMission(int id);
+	int getCount();
+	String getLocation();
 }

--- a/app/src/main/java/us/shandian/giga/get/DownloadMission.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadMission.java
@@ -20,12 +20,12 @@ public class DownloadMission
 {
 	private static final String TAG = DownloadMission.class.getSimpleName();
 	
-	public static interface MissionListener {
+	public interface MissionListener {
 		HashMap<MissionListener, Handler> handlerStore = new HashMap<>();
 		
-		public void onProgressUpdate(long done, long total);
-		public void onFinish();
-		public void onError(int errCode);
+		void onProgressUpdate(long done, long total);
+		void onFinish();
+		void onError(int errCode);
 	}
 	
 	public static final int ERROR_SERVER_UNSUPPORTED = 206;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2333 - Redundant modifiers should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2333

Please let me know if you have any questions.

Faisal Hameed