### PR TITLE
Set IMMERSIVE_STICKY for Exoplayer

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ExoPlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ExoPlayerActivity.java
@@ -368,6 +368,20 @@ public class ExoPlayerActivity extends Activity {
         }
         shutterView.setVisibility(View.VISIBLE);
     }
+    
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (hasFocus) {
+            getWindow().getDecorView().setSystemUiVisibility(
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                            | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                            | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                            | View.SYSTEM_UI_FLAG_FULLSCREEN
+                            | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+        }
+    }
 
     @Override
     public void onDestroy() {


### PR DESCRIPTION
Fixes #253. Mostly taken from [the docs](https://developer.android.com/training/system-ui/immersive.html#sticky).

Interestingly, the docs recommend the use of IMMERSIVE for video playback while the actual YouTube app uses IMMERSIVE_STICKY. Personally, I think that IMMERSIVE_STICKY is more functional and is what people will be used to, so I went with that.